### PR TITLE
feat: export studio as genlayer chain

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "genlayer-py"
-version = "0.2.0"
+version = "0.2.1"
 description = "GenLayer Python SDK"
 authors = [
     { name = "GenLayer" }


### PR DESCRIPTION
Fixes DXP-354

## What

- Added export for studionet chain configuration in `genlayer_py/chains/__init__.py`
- Added tests for each network

Why
- To make the Genlayer Studio Network chain configuration available for import and use in applications
- Enables developers to connect to the studio environment at https://studio.genlayer.com/api