### PR TITLE
fix: return simplified transaction object on error

### DIFF
--- a/genlayer_py/transactions/actions.py
+++ b/genlayer_py/transactions/actions.py
@@ -100,7 +100,7 @@ def wait_for_transaction_receipt(
         f"Last observed status: '{last_status.value}'. "
         f"This may indicate the transaction is still processing, or the network is experiencing delays. "
         f"Consider increasing 'retries' or 'interval' parameters.\n"
-        f"Transaction object: {json.dumps(transaction, indent=2, default=str)}"
+        f"Transaction object simplified: {json.dumps(_simplify_transaction_receipt(transaction), indent=2, default=str)}"
     )
 
 


### PR DESCRIPTION
Fixes DXP-535

## What

- Return simplified transaction object when desired state is not reached



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for failed transactions by displaying a simplified transaction receipt, making them easier to read and less cluttered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->