### PR TITLE
fix: add payload to exception to improve debugging capabilities

### DIFF
--- a/genlayer_py/consensus/abi/__init__.py
+++ b/genlayer_py/consensus/abi/__init__.py
@@ -1,18 +1,24 @@
 import json
 import importlib.resources
 
-with importlib.resources.as_file(
-    importlib.resources.files("genlayer_py.consensus.abi").joinpath(
-        "consensus_data_abi.json"
-    )
-) as path, open(path, "r", encoding="utf-8") as f:
+with (
+    importlib.resources.as_file(
+        importlib.resources.files("genlayer_py.consensus.abi").joinpath(
+            "consensus_data_abi.json"
+        )
+    ) as path,
+    open(path, "r", encoding="utf-8") as f,
+):
     CONSENSUS_DATA_ABI = json.load(f)
 
-with importlib.resources.as_file(
-    importlib.resources.files("genlayer_py.consensus.abi").joinpath(
-        "consensus_main_abi.json"
-    )
-) as path, open(path, "r", encoding="utf-8") as f:
+with (
+    importlib.resources.as_file(
+        importlib.resources.files("genlayer_py.consensus.abi").joinpath(
+            "consensus_main_abi.json"
+        )
+    ) as path,
+    open(path, "r", encoding="utf-8") as f,
+):
     CONSENSUS_MAIN_ABI = json.load(f)
 
 __all__ = ["CONSENSUS_DATA_ABI", "CONSENSUS_MAIN_ABI"]

--- a/genlayer_py/exceptions.py
+++ b/genlayer_py/exceptions.py
@@ -1,4 +1,27 @@
+from typing import Any, Optional
+
+
 class GenLayerError(Exception):
+    """Base exception class for GenLayer SDK errors.
+
+    This exception can carry additional context information through an optional
+    payload dictionary, useful for debugging and error handling.
+
+    Args:
+        message: Human-readable error description.
+        payload: Optional dictionary containing additional error context,
+                 such as transaction details, error codes, or debug information.
+
+    Attributes:
+        payload: Dictionary of additional error context (None if not provided).
+
+    Example:
+        >>> raise GenLayerError(
+        ...     "Transaction failed",
+        ...     {"tx_hash": "0x123...", "reason": "insufficient funds"}
+        ... )
     """
-    An error raised by GenLayer.
-    """
+
+    def __init__(self, message: str, payload: Optional[dict[str, Any]] = None):
+        super().__init__(message)
+        self.payload = payload

--- a/genlayer_py/provider/provider.py
+++ b/genlayer_py/provider/provider.py
@@ -38,9 +38,14 @@ class GenLayerProvider(BaseProvider):
         try:
             resp = response.json()
         except ValueError as err:
-            response_preview = response.text[:500] if len(response.text) <= 500 else f"{response.text[:500]}..."
+            response_preview = (
+                response.text[:500]
+                if len(response.text) <= 500
+                else f"{response.text[:500]}..."
+            )
             raise GenLayerError(
-                f"{method} returned invalid JSON: {err}. Response content: {response_preview}"
+                f"{method} returned invalid JSON: {err}. Response content: {response_preview}",
+                payload={"response": response},
             ) from err
         self._raise_on_error(resp, method)
         return resp

--- a/genlayer_py/types/transactions.py
+++ b/genlayer_py/types/transactions.py
@@ -68,11 +68,14 @@ DECIDED_STATES = [
     TransactionStatus.LEADER_TIMEOUT,
     TransactionStatus.VALIDATORS_TIMEOUT,
     TransactionStatus.CANCELED,
-    TransactionStatus.FINALIZED
+    TransactionStatus.FINALIZED,
 ]
 
+
 def is_decided_state(status: str) -> bool:
-    return status in [TRANSACTION_STATUS_NAME_TO_NUMBER[state] for state in DECIDED_STATES]
+    return status in [
+        TRANSACTION_STATUS_NAME_TO_NUMBER[state] for state in DECIDED_STATES
+    ]
 
 
 class TransactionResult(str, Enum):

--- a/tests/unit/transactions/test_wait_for_transaction_receipt.py
+++ b/tests/unit/transactions/test_wait_for_transaction_receipt.py
@@ -136,8 +136,15 @@ class TestWaitForTransactionReceipt:
 
     def test_wait_for_accepted_with_all_decided_states(self, mock_client):
         """Test that ACCEPTED status accepts all decided states"""
-        decided_statuses = ["5", "6", "8", "7", "12", "13"]  # ACCEPTED, UNDETERMINED, CANCELED, FINALIZED, VALIDATORS_TIMEOUT, LEADER_TIMEOUT
-        
+        decided_statuses = [
+            "5",
+            "6",
+            "8",
+            "7",
+            "12",
+            "13",
+        ]  # ACCEPTED, UNDETERMINED, CANCELED, FINALIZED, VALIDATORS_TIMEOUT, LEADER_TIMEOUT
+
         for status_num in decided_statuses:
             mock_transaction = {
                 "hash": "0x4b8037744adab7ea8335b4f839979d20031d83a8ccdf706e0ae61312930335f6",
@@ -150,16 +157,16 @@ class TestWaitForTransactionReceipt:
                 "nonce": "1",
                 "created_at": "2023-01-01T00:00:00Z",
             }
-            
+
             mock_client.get_transaction.return_value = mock_transaction
-            
+
             result = wait_for_transaction_receipt(
                 self=mock_client,
                 transaction_hash="0x4b8037744adab7ea8335b4f839979d20031d83a8ccdf706e0ae61312930335f6",
                 status=TransactionStatus.ACCEPTED,
                 full_transaction=True,
             )
-            
+
             assert result == mock_transaction
 
     def test_wait_for_specific_status_not_affected(self, mock_client):
@@ -175,16 +182,16 @@ class TestWaitForTransactionReceipt:
             "nonce": "1",
             "created_at": "2023-01-01T00:00:00Z",
         }
-        
+
         mock_client.get_transaction.return_value = mock_transaction
-        
+
         result = wait_for_transaction_receipt(
             self=mock_client,
             transaction_hash="0x4b8037744adab7ea8335b4f839979d20031d83a8ccdf706e0ae61312930335f6",
             status=TransactionStatus.FINALIZED,
             full_transaction=True,
         )
-        
+
         assert result == mock_transaction
 
 
@@ -199,32 +206,54 @@ class TestDecidedStatesUtility:
             TransactionStatus.LEADER_TIMEOUT,
             TransactionStatus.VALIDATORS_TIMEOUT,
             TransactionStatus.CANCELED,
-            TransactionStatus.FINALIZED
+            TransactionStatus.FINALIZED,
         ]
-        
+
         assert DECIDED_STATES == expected_states
 
     def test_is_decided_state_with_decided_statuses(self):
         """Test is_decided_state returns True for all decided statuses"""
-        decided_status_numbers = ["5", "6", "8", "7", "12", "13"]  # ACCEPTED, UNDETERMINED, CANCELED, FINALIZED, VALIDATORS_TIMEOUT, LEADER_TIMEOUT
-        
+        decided_status_numbers = [
+            "5",
+            "6",
+            "8",
+            "7",
+            "12",
+            "13",
+        ]  # ACCEPTED, UNDETERMINED, CANCELED, FINALIZED, VALIDATORS_TIMEOUT, LEADER_TIMEOUT
+
         for status_num in decided_status_numbers:
-            assert is_decided_state(status_num) == True, f"Status {status_num} should be decided"
+            assert (
+                is_decided_state(status_num) == True
+            ), f"Status {status_num} should be decided"
 
     def test_is_decided_state_with_non_decided_statuses(self):
         """Test is_decided_state returns False for non-decided statuses"""
-        non_decided_status_numbers = ["0", "1", "2", "3", "4", "9", "10", "11"]  # UNINITIALIZED, PENDING, PROPOSING, COMMITTING, REVEALING, APPEAL_REVEALING, APPEAL_COMMITTING, READY_TO_FINALIZE
-        
+        non_decided_status_numbers = [
+            "0",
+            "1",
+            "2",
+            "3",
+            "4",
+            "9",
+            "10",
+            "11",
+        ]  # UNINITIALIZED, PENDING, PROPOSING, COMMITTING, REVEALING, APPEAL_REVEALING, APPEAL_COMMITTING, READY_TO_FINALIZE
+
         for status_num in non_decided_status_numbers:
-            assert is_decided_state(status_num) == False, f"Status {status_num} should not be decided"
+            assert (
+                is_decided_state(status_num) == False
+            ), f"Status {status_num} should not be decided"
 
     def test_is_decided_state_with_invalid_status(self):
         """Test is_decided_state returns False for invalid statuses"""
         invalid_statuses = ["999", "invalid", "", None]
-        
+
         for status in invalid_statuses:
             if status is not None:
-                assert is_decided_state(status) == False, f"Invalid status {status} should not be decided"
+                assert (
+                    is_decided_state(status) == False
+                ), f"Invalid status {status} should not be decided"
 
 
 class TestSimplifyTransactionReceipt:


### PR DESCRIPTION
Related #57 

Fixes: DXP-687

## What

- Add payload to genlayer exception to improve debugging capabilities
- Raise with additional payload in make request method


# Example: Accessing the payload

```
try:
  print(f"Calling sim_getTransactionsForAddress with wallet: {wallet_address}")
  response = client.provider.make_request(
    method="sim_getTransactionsForAddress", params=[wallet_address]
  )

except GenLayerError as e:
  payload = e.payload
  if payload is not None and "response" in payload:
    response = e.payload["response"]
    print(f"Response: {response.text}")
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Errors now carry optional contextual payloads for easier troubleshooting.
  * “Finalized” is recognized as a decided transaction state, improving status handling.

* **Refactor**
  * Consolidated resource loading and response preview construction; no functional changes.

* **Style**
  * Minor formatting and line-wrapping cleanups across modules.

* **Tests**
  * Reformatted unit tests for readability; no changes to test behavior or coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->