### PR TITLE
feat: update consensus ABI to v0.5 IConsensusMain interface

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,31 @@
+name: Smoke Tests
+
+on:
+  schedule:
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    name: Testnet Smoke Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      matrix:
+        python-version: ['3.12']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          pip install -r requirements.test.txt
+
+      - name: Run smoke tests
+        run: pytest tests/unit/smoke -v -m testnet

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,6 +1,7 @@
 name: Smoke Tests
 
 on:
+  pull_request:
   schedule:
     - cron: '0 8 * * *'
   workflow_dispatch:
@@ -10,6 +11,7 @@ jobs:
     name: Testnet Smoke Tests
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    continue-on-error: true
     strategy:
       matrix:
         python-version: ['3.12']

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,4 +29,4 @@ jobs:
           pip install -r requirements.test.txt
 
       - name: Action | Run Unit Tests
-        run: pytest tests/unit --disable-warnings -v
+        run: pytest tests/unit --disable-warnings -v -m "not testnet"

--- a/genlayer_py/chains/testnet_asimov.py
+++ b/genlayer_py/chains/testnet_asimov.py
@@ -3,7 +3,7 @@ from genlayer_py.consensus.abi import CONSENSUS_MAIN_ABI, CONSENSUS_DATA_ABI
 
 
 TESTNET_JSON_RPC_URL = "https://zksync-os-testnet-genlayer.zksync.dev"
-TESTNET_WS_URL = "wss://zksync-os-testnet-alpha.zksync.dev/ws"
+TESTNET_WS_URL = "wss://zksync-os-testnet-genlayer.zksync.dev/ws"
 EXPLORER_URL = "https://explorer-asimov.genlayer.com/"
 
 CONSENSUS_MAIN_CONTRACT = {

--- a/genlayer_py/consensus/abi/consensus_main_abi.json
+++ b/genlayer_py/consensus/abi/consensus_main_abi.json
@@ -1,127 +1,60 @@
 [
   {
-    "inputs": [],
-    "name": "AccessControlBadConfirmation",
-    "type": "error"
-  },
-  {
+    "anonymous": false,
     "inputs": [
       {
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      },
-      {
+        "indexed": true,
         "internalType": "bytes32",
-        "name": "neededRole",
+        "name": "txId",
         "type": "bytes32"
-      }
-    ],
-    "name": "AccessControlUnauthorizedAccount",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "CallerNotMessages",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "CanNotAppeal",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "EmptyTransaction",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "FinalizationNotAllowed",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "InvalidAddress",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "InvalidGhostContract",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "InvalidInitialization",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "InvalidVote",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "MaxNumOfIterationsInPendingQueueReached",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "numOfMessages",
-        "type": "uint256"
       },
       {
-        "internalType": "uint256",
-        "name": "maxAllocatedMessages",
-        "type": "uint256"
-      }
-    ],
-    "name": "MaxNumOfMessagesExceeded",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "NonGenVMContract",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "NotInitializing",
-    "type": "error"
-  },
-  {
-    "inputs": [
-      {
+        "indexed": true,
         "internalType": "address",
-        "name": "owner",
+        "name": "oldActivator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newActivator",
         "type": "address"
       }
     ],
-    "name": "OwnableInvalidOwner",
-    "type": "error"
+    "name": "ActivatorReplaced",
+    "type": "event"
   },
   {
+    "anonymous": false,
     "inputs": [
       {
+        "indexed": true,
         "internalType": "address",
-        "name": "account",
+        "name": "addressManager",
         "type": "address"
       }
     ],
-    "name": "OwnableUnauthorizedAccount",
-    "type": "error"
+    "name": "AddressManagerSet",
+    "type": "event"
   },
   {
-    "inputs": [],
-    "name": "ReentrancyGuardReentrantCall",
-    "type": "error"
-  },
-  {
-    "inputs": [],
-    "name": "TransactionNotAtPendingQueueHead",
-    "type": "error"
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum ITransactions.TransactionStatus",
+        "name": "newStatus",
+        "type": "uint8"
+      }
+    ],
+    "name": "AllVotesCommitted",
+    "type": "event"
   },
   {
     "anonymous": false,
@@ -135,19 +68,19 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "appealer",
+        "name": "appellant",
         "type": "address"
       },
       {
         "indexed": false,
         "internalType": "uint256",
-        "name": "appealBond",
+        "name": "bond",
         "type": "uint256"
       },
       {
         "indexed": false,
         "internalType": "address[]",
-        "name": "appealValidators",
+        "name": "validators",
         "type": "address[]"
       }
     ],
@@ -158,93 +91,44 @@
     "anonymous": false,
     "inputs": [
       {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "attempted",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "succeeded",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "failed",
+        "type": "uint256"
+      }
+    ],
+    "name": "BatchFinalizationCompleted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
         "indexed": true,
         "internalType": "bytes32",
         "name": "txId",
         "type": "bytes32"
       },
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "recipient",
-        "type": "address"
-      },
-      {
         "indexed": false,
-        "internalType": "bytes",
-        "name": "data",
-        "type": "bytes"
+        "internalType": "uint256",
+        "name": "txSlot",
+        "type": "uint256"
       }
     ],
-    "name": "ErrorMessage",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "ghostFactory",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "genManager",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "genTransactions",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "genQueue",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "genStaking",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "genMessages",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "idleness",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "address",
-        "name": "tribunalAppeal",
-        "type": "address"
-      }
-    ],
-    "name": "ExternalContractsSet",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "uint64",
-        "name": "version",
-        "type": "uint64"
-      }
-    ],
-    "name": "Initialized",
+    "name": "CreatedTransaction",
     "type": "event"
   },
   {
@@ -284,6 +168,31 @@
       {
         "indexed": true,
         "internalType": "address",
+        "name": "oldLeader",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newLeader",
+        "type": "address"
+      }
+    ],
+    "name": "LeaderIdlenessProcessed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
         "name": "recipient",
         "type": "address"
       },
@@ -302,112 +211,12 @@
     "inputs": [
       {
         "indexed": true,
-        "internalType": "address",
-        "name": "previousOwner",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "newOwner",
-        "type": "address"
-      }
-    ],
-    "name": "OwnershipTransferStarted",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "previousOwner",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "newOwner",
-        "type": "address"
-      }
-    ],
-    "name": "OwnershipTransferred",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
         "internalType": "bytes32",
-        "name": "role",
-        "type": "bytes32"
-      },
-      {
-        "indexed": true,
-        "internalType": "bytes32",
-        "name": "previousAdminRole",
-        "type": "bytes32"
-      },
-      {
-        "indexed": true,
-        "internalType": "bytes32",
-        "name": "newAdminRole",
+        "name": "txId",
         "type": "bytes32"
       }
     ],
-    "name": "RoleAdminChanged",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "bytes32",
-        "name": "role",
-        "type": "bytes32"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "sender",
-        "type": "address"
-      }
-    ],
-    "name": "RoleGranted",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "bytes32",
-        "name": "role",
-        "type": "bytes32"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "sender",
-        "type": "address"
-      }
-    ],
-    "name": "RoleRevoked",
+    "name": "ProcessIdlenessAccepted",
     "type": "event"
   },
   {
@@ -417,25 +226,6 @@
         "indexed": true,
         "internalType": "bytes32",
         "name": "txId",
-        "type": "bytes32"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "sender",
-        "type": "address"
-      }
-    ],
-    "name": "SlashAppealSubmitted",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "bytes32",
-        "name": "tx_id",
         "type": "bytes32"
       }
     ],
@@ -473,7 +263,7 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "sender",
+        "name": "cancelledBy",
         "type": "address"
       }
     ],
@@ -486,7 +276,20 @@
       {
         "indexed": true,
         "internalType": "bytes32",
-        "name": "tx_id",
+        "name": "txId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "TransactionFinalizationFailed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
         "type": "bytes32"
       }
     ],
@@ -501,40 +304,9 @@
         "internalType": "bytes32",
         "name": "txId",
         "type": "bytes32"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "oldValidator",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "newValidator",
-        "type": "address"
       }
     ],
-    "name": "TransactionIdleValidatorReplaced",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "bytes32",
-        "name": "txId",
-        "type": "bytes32"
-      },
-      {
-        "indexed": true,
-        "internalType": "uint256",
-        "name": "validatorIndex",
-        "type": "uint256"
-      }
-    ],
-    "name": "TransactionIdleValidatorReplacementFailed",
+    "name": "TransactionLeaderRevealed",
     "type": "event"
   },
   {
@@ -562,7 +334,7 @@
       {
         "indexed": true,
         "internalType": "bytes32",
-        "name": "tx_id",
+        "name": "txId",
         "type": "bytes32"
       }
     ],
@@ -575,7 +347,7 @@
       {
         "indexed": false,
         "internalType": "bytes32[]",
-        "name": "tx_ids",
+        "name": "txIds",
         "type": "bytes32[]"
       }
     ],
@@ -588,7 +360,7 @@
       {
         "indexed": true,
         "internalType": "bytes32",
-        "name": "tx_id",
+        "name": "txId",
         "type": "bytes32"
       },
       {
@@ -607,7 +379,7 @@
       {
         "indexed": true,
         "internalType": "bytes32",
-        "name": "tx_id",
+        "name": "txId",
         "type": "bytes32"
       }
     ],
@@ -624,16 +396,16 @@
         "type": "bytes32"
       },
       {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tribunalIndex",
+        "type": "uint256"
+      },
+      {
         "indexed": true,
         "internalType": "address",
         "name": "validator",
         "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "bool",
-        "name": "isLastVote",
-        "type": "bool"
       }
     ],
     "name": "TribunalAppealVoteCommitted",
@@ -649,6 +421,12 @@
         "type": "bytes32"
       },
       {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "tribunalIndex",
+        "type": "uint256"
+      },
+      {
         "indexed": true,
         "internalType": "address",
         "name": "validator",
@@ -656,12 +434,68 @@
       },
       {
         "indexed": false,
-        "internalType": "bool",
-        "name": "isLastVote",
-        "type": "bool"
+        "internalType": "enum ITransactions.VoteType",
+        "name": "voteType",
+        "type": "uint8"
       }
     ],
     "name": "TribunalAppealVoteRevealed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "oldValidator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newValidator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "validatorIndex",
+        "type": "uint256"
+      }
+    ],
+    "name": "ValidatorReplaced",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "txId",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "recipient",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "ValueWithdrawalFailed",
     "type": "event"
   },
   {
@@ -727,31 +561,16 @@
     "type": "event"
   },
   {
-    "inputs": [],
-    "name": "DEFAULT_ADMIN_ROLE",
-    "outputs": [
-      {
-        "internalType": "bytes32",
-        "name": "",
-        "type": "bytes32"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "acceptOwnership",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
     "inputs": [
       {
         "internalType": "bytes32",
         "name": "_txId",
         "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "_operator",
+        "type": "address"
       },
       {
         "internalType": "bytes",
@@ -788,13 +607,18 @@
       },
       {
         "internalType": "bytes",
-        "name": "_txData",
+        "name": "_calldata",
         "type": "bytes"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_validUntil",
+        "type": "uint256"
       }
     ],
     "name": "addTransaction",
     "outputs": [],
-    "stateMutability": "nonpayable",
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -818,6 +642,11 @@
         "type": "bytes32"
       },
       {
+        "internalType": "uint256",
+        "name": "_tribunalIndex",
+        "type": "uint256"
+      },
+      {
         "internalType": "bytes32",
         "name": "_commitHash",
         "type": "bytes32"
@@ -839,6 +668,11 @@
         "internalType": "bytes32",
         "name": "_commitHash",
         "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_validatorIndex",
+        "type": "uint256"
       }
     ],
     "name": "commitVote",
@@ -847,51 +681,41 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "contracts",
-    "outputs": [
+    "inputs": [
       {
-        "internalType": "contract IGenManager",
-        "name": "genManager",
+        "internalType": "address",
+        "name": "_sender",
         "type": "address"
       },
       {
-        "internalType": "contract ITransactions",
-        "name": "genTransactions",
-        "type": "address"
+        "internalType": "uint256",
+        "name": "_numOfInitialValidators",
+        "type": "uint256"
       },
       {
-        "internalType": "contract IQueues",
-        "name": "genQueue",
-        "type": "address"
+        "internalType": "uint256",
+        "name": "_maxRotations",
+        "type": "uint256"
       },
       {
-        "internalType": "contract IGhostFactory",
-        "name": "ghostFactory",
-        "type": "address"
+        "internalType": "bytes",
+        "name": "_calldata",
+        "type": "bytes"
       },
       {
-        "internalType": "contract IGenStaking",
-        "name": "genStaking",
-        "type": "address"
+        "internalType": "uint256",
+        "name": "_saltNonce",
+        "type": "uint256"
       },
       {
-        "internalType": "contract IMessages",
-        "name": "genMessages",
-        "type": "address"
-      },
-      {
-        "internalType": "contract IIdleness",
-        "name": "idleness",
-        "type": "address"
-      },
-      {
-        "internalType": "contract ITribunalAppeal",
-        "name": "tribunalAppeal",
-        "type": "address"
+        "internalType": "uint256",
+        "name": "_validUntil",
+        "type": "uint256"
       }
     ],
-    "stateMutability": "view",
+    "name": "deploySalted",
+    "outputs": [],
+    "stateMutability": "payable",
     "type": "function"
   },
   {
@@ -926,6 +750,19 @@
   {
     "inputs": [
       {
+        "internalType": "bytes32[]",
+        "name": "_txIds",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "finalizeIdlenessTxs",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "bytes32",
         "name": "_txId",
         "type": "bytes32"
@@ -937,55 +774,26 @@
     "type": "function"
   },
   {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_txId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "flushExternalMessages",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [],
-    "name": "getContracts",
+    "name": "getAddressManager",
     "outputs": [
       {
-        "components": [
-          {
-            "internalType": "contract IGenManager",
-            "name": "genManager",
-            "type": "address"
-          },
-          {
-            "internalType": "contract ITransactions",
-            "name": "genTransactions",
-            "type": "address"
-          },
-          {
-            "internalType": "contract IQueues",
-            "name": "genQueue",
-            "type": "address"
-          },
-          {
-            "internalType": "contract IGhostFactory",
-            "name": "ghostFactory",
-            "type": "address"
-          },
-          {
-            "internalType": "contract IGenStaking",
-            "name": "genStaking",
-            "type": "address"
-          },
-          {
-            "internalType": "contract IMessages",
-            "name": "genMessages",
-            "type": "address"
-          },
-          {
-            "internalType": "contract IIdleness",
-            "name": "idleness",
-            "type": "address"
-          },
-          {
-            "internalType": "contract ITribunalAppeal",
-            "name": "tribunalAppeal",
-            "type": "address"
-          }
-        ],
-        "internalType": "struct IConsensusMain.ExternalContracts",
+        "internalType": "contract IAddressManager",
         "name": "",
-        "type": "tuple"
+        "type": "address"
       }
     ],
     "stateMutability": "view",
@@ -995,16 +803,16 @@
     "inputs": [
       {
         "internalType": "bytes32",
-        "name": "role",
+        "name": "txId",
         "type": "bytes32"
       }
     ],
-    "name": "getRoleAdmin",
+    "name": "getPendingTransactionValue",
     "outputs": [
       {
-        "internalType": "bytes32",
+        "internalType": "uint256",
         "name": "",
-        "type": "bytes32"
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -1018,49 +826,7 @@
         "type": "address"
       }
     ],
-    "name": "ghostContracts",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "isGhost",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "role",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      }
-    ],
-    "name": "grantRole",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "role",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "address",
-        "name": "account",
-        "type": "address"
-      }
-    ],
-    "name": "hasRole",
+    "name": "isGhostContract",
     "outputs": [
       {
         "internalType": "bool",
@@ -1072,47 +838,109 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "initialize",
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_txId",
+        "type": "bytes32"
+      }
+    ],
+    "name": "leaderIdleness",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "owner",
-    "outputs": [
+    "inputs": [
       {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
+        "components": [
+          {
+            "internalType": "bytes32",
+            "name": "txId",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "uint256",
+            "name": "saltAsAValidator",
+            "type": "uint256"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "txExecutionHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "messagesAndOtherFieldsHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "bytes32",
+            "name": "otherExecutionFieldsHash",
+            "type": "bytes32"
+          },
+          {
+            "internalType": "enum ITransactions.VoteType",
+            "name": "resultValue",
+            "type": "uint8"
+          },
+          {
+            "components": [
+              {
+                "internalType": "enum IMessages.MessageType",
+                "name": "messageType",
+                "type": "uint8"
+              },
+              {
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address"
+              },
+              {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+              },
+              {
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+              },
+              {
+                "internalType": "bool",
+                "name": "onAcceptance",
+                "type": "bool"
+              },
+              {
+                "internalType": "uint256",
+                "name": "saltNonce",
+                "type": "uint256"
+              }
+            ],
+            "internalType": "struct IMessages.SubmittedMessage[]",
+            "name": "messages",
+            "type": "tuple[]"
+          }
+        ],
+        "internalType": "struct IConsensusMain.LeaderRevealVoteParams",
+        "name": "leaderRevealVoteParams",
+        "type": "tuple"
       }
     ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "pendingOwner",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
+    "name": "leaderRevealVote",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [
       {
-        "internalType": "address",
-        "name": "recipient",
-        "type": "address"
+        "internalType": "bytes32",
+        "name": "_txId",
+        "type": "bytes32"
       }
     ],
-    "name": "proceedPendingQueueProcessing",
+    "name": "processIdleness",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -1125,9 +953,9 @@
         "type": "bytes32"
       },
       {
-        "internalType": "bytes",
-        "name": "_txReceipt",
-        "type": "bytes"
+        "internalType": "bytes32",
+        "name": "_txExecutionHash",
+        "type": "bytes32"
       },
       {
         "internalType": "uint256",
@@ -1135,36 +963,14 @@
         "type": "uint256"
       },
       {
-        "components": [
-          {
-            "internalType": "enum IMessages.MessageType",
-            "name": "messageType",
-            "type": "uint8"
-          },
-          {
-            "internalType": "address",
-            "name": "recipient",
-            "type": "address"
-          },
-          {
-            "internalType": "uint256",
-            "name": "value",
-            "type": "uint256"
-          },
-          {
-            "internalType": "bytes",
-            "name": "data",
-            "type": "bytes"
-          },
-          {
-            "internalType": "bool",
-            "name": "onAcceptance",
-            "type": "bool"
-          }
-        ],
-        "internalType": "struct IMessages.SubmittedMessage[]",
-        "name": "_messages",
-        "type": "tuple[]"
+        "internalType": "address",
+        "name": "_operator",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "_eqBlocksOutputs",
+        "type": "bytes"
       },
       {
         "internalType": "bytes",
@@ -1178,8 +984,14 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "renounceOwnership",
+    "inputs": [
+      {
+        "internalType": "bytes32[]",
+        "name": "_txIds",
+        "type": "bytes32[]"
+      }
+    ],
+    "name": "redButtonFinalize",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -1187,17 +999,12 @@
   {
     "inputs": [
       {
-        "internalType": "bytes32",
-        "name": "role",
-        "type": "bytes32"
-      },
-      {
         "internalType": "address",
-        "name": "callerConfirmation",
+        "name": "ghost",
         "type": "address"
       }
     ],
-    "name": "renounceRole",
+    "name": "registerGhostContract",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -1210,14 +1017,24 @@
         "type": "bytes32"
       },
       {
+        "internalType": "uint256",
+        "name": "_tribunalIndex",
+        "type": "uint256"
+      },
+      {
         "internalType": "bytes32",
         "name": "_voteHash",
         "type": "bytes32"
       },
       {
-        "internalType": "enum ITribunalAppeal.TribunalVoteType",
+        "internalType": "enum ITransactions.VoteType",
         "name": "_voteType",
         "type": "uint8"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_otherExecutionFieldsHash",
+        "type": "bytes32"
       },
       {
         "internalType": "uint256",
@@ -1248,8 +1065,18 @@
         "type": "uint8"
       },
       {
+        "internalType": "bytes32",
+        "name": "_otherExecutionFieldsHash",
+        "type": "bytes32"
+      },
+      {
         "internalType": "uint256",
         "name": "_nonce",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_validatorIndex",
         "type": "uint256"
       }
     ],
@@ -1261,65 +1088,12 @@
   {
     "inputs": [
       {
-        "internalType": "bytes32",
-        "name": "role",
-        "type": "bytes32"
-      },
-      {
         "internalType": "address",
-        "name": "account",
+        "name": "_addressManager",
         "type": "address"
       }
     ],
-    "name": "revokeRole",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "_ghostFactory",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "_genManager",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "_genTransactions",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "_genQueue",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "_genStaking",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "_genMessages",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "_idleness",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "_tribunalAppeal",
-        "type": "address"
-      }
-    ],
-    "name": "setExternalContracts",
+    "name": "setAddressManager",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -1335,51 +1109,6 @@
     "name": "submitAppeal",
     "outputs": [],
     "stateMutability": "payable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "_txId",
-        "type": "bytes32"
-      }
-    ],
-    "name": "submitSlashAppeal",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "bytes4",
-        "name": "interfaceId",
-        "type": "bytes4"
-      }
-    ],
-    "name": "supportsInterface",
-    "outputs": [
-      {
-        "internalType": "bool",
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "newOwner",
-        "type": "address"
-      }
-    ],
-    "name": "transferOwnership",
-    "outputs": [],
-    "stateMutability": "nonpayable",
     "type": "function"
   }
 ]

--- a/genlayer_py/consensus/consensus_main/decoder.py
+++ b/genlayer_py/consensus/consensus_main/decoder.py
@@ -26,6 +26,7 @@ def decode_add_transaction_data(encoded_data):
             "encoded": encoded_tx_data,
             "decoded": decoded_tx_data,
         },
+        "valid_until": abi_decoded[5],
     }
 
 

--- a/genlayer_py/consensus/consensus_main/encoder.py
+++ b/genlayer_py/consensus/consensus_main/encoder.py
@@ -16,6 +16,7 @@ def encode_add_transaction_data(
     num_of_initial_validators: int,
     max_rotations: int,
     tx_data: HexStr,
+    valid_until: int = 0,
 ):
     w3 = Web3()
     consensus_main_contract = w3.eth.contract(abi=CONSENSUS_MAIN_ABI)
@@ -29,6 +30,7 @@ def encode_add_transaction_data(
             num_of_initial_validators,
             max_rotations,
             w3.to_bytes(hexstr=tx_data),
+            valid_until,
         ],
     )
     function_selector = eth_utils.keccak(text=contract_fn.signature)[:4].hex()

--- a/genlayer_py/contracts/actions.py
+++ b/genlayer_py/contracts/actions.py
@@ -245,6 +245,7 @@ def _encode_add_transaction_data(
     recipient,
     consensus_max_rotations,
     data,
+    valid_until: int = 0,
 ):
     consensus_main_contract = self.w3.eth.contract(
         abi=self.chain.consensus_main_contract["abi"]
@@ -258,6 +259,7 @@ def _encode_add_transaction_data(
             self.chain.default_number_of_initial_validators,
             consensus_max_rotations,
             self.w3.to_bytes(hexstr=data),
+            valid_until,
         ],
     )
     function_selector = eth_utils.keccak(text=contract_fn.signature)[:4].hex()

--- a/tests/unit/smoke/test_testnet_smoke.py
+++ b/tests/unit/smoke/test_testnet_smoke.py
@@ -50,3 +50,121 @@ class TestTestnetConnectivity:
     def test_block_number_positive(self):
         w3 = Web3(Web3.HTTPProvider(TESTNET_JSON_RPC_URL))
         assert w3.eth.block_number > 0
+
+
+@pytest.mark.testnet
+class TestConsensusContractReadOnly:
+    """Verify the consensus main contract ABI matches the deployed contract."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        from genlayer_py.consensus.abi import CONSENSUS_MAIN_ABI
+
+        self.w3 = Web3(Web3.HTTPProvider(TESTNET_JSON_RPC_URL))
+        self.contract = self.w3.eth.contract(
+            address=Web3.to_checksum_address(CONSENSUS_MAIN_CONTRACT["address"]),
+            abi=CONSENSUS_MAIN_ABI,
+        )
+
+    def test_get_address_manager(self):
+        """Call getAddressManager() — zero-arg view function."""
+        result = self.contract.functions.getAddressManager().call()
+        # Should return a valid non-zero address
+        assert Web3.is_address(result)
+        assert result != "0x0000000000000000000000000000000000000000"
+
+    def test_is_ghost_contract_zero_address(self):
+        """Call isGhostContract with the zero address."""
+        result = self.contract.functions.isGhostContract(
+            "0x0000000000000000000000000000000000000000"
+        ).call()
+        assert isinstance(result, bool)
+
+    def test_get_pending_transaction_value_zero(self):
+        """Call getPendingTransactionValue with a zero txId."""
+        result = self.contract.functions.getPendingTransactionValue(b"\x00" * 32).call()
+        assert isinstance(result, int)
+        assert result == 0
+
+
+@pytest.mark.testnet
+class TestEncoderDecoderRoundTrip:
+    """Verify encode/decode round-trip for addTransaction data."""
+
+    def test_round_trip_call(self):
+        from genlayer_py.consensus.consensus_main.encoder import (
+            encode_add_transaction_data,
+            encode_tx_data_call,
+        )
+        from genlayer_py.consensus.consensus_main.decoder import (
+            decode_add_transaction_data,
+        )
+
+        sender = "0xABcdEFABcdEFabcdEfAbCdefAbCdEFaBcDEFabCD"
+        recipient = "0x1111111111111111111111111111111111111111"
+        num_validators = 7
+        max_rotations = 2
+
+        tx_data = encode_tx_data_call(
+            function_name="my_method",
+            leader_only=True,
+            args=["hello"],
+            kwargs={"key": "value"},
+        )
+
+        encoded = encode_add_transaction_data(
+            sender_address=sender,
+            recipient_address=recipient,
+            num_of_initial_validators=num_validators,
+            max_rotations=max_rotations,
+            tx_data=tx_data.hex() if isinstance(tx_data, bytes) else tx_data,
+        )
+
+        decoded = decode_add_transaction_data(encoded)
+        assert decoded["sender_address"].lower() == sender.lower()
+        assert decoded["recipient_address"].lower() == recipient.lower()
+        assert decoded["num_of_initial_validators"] == num_validators
+        assert decoded["max_rotations"] == max_rotations
+        assert decoded["tx_data"]["decoded"]["call_data"]["method"] == "my_method"
+        assert decoded["tx_data"]["decoded"]["leader_only"] is True
+        assert decoded["tx_data"]["decoded"]["type"] == "call"
+
+    def test_round_trip_deploy(self):
+        from genlayer_py.consensus.consensus_main.encoder import (
+            encode_add_transaction_data,
+            encode_tx_data_deploy,
+        )
+        from genlayer_py.consensus.consensus_main.decoder import (
+            decode_add_transaction_data,
+        )
+
+        sender = "0xABcdEFABcdEFabcdEfAbCdefAbCdEFaBcDEFabCD"
+        recipient = "0x0000000000000000000000000000000000000000"
+        code = "print('hello world')"
+
+        tx_data = encode_tx_data_deploy(
+            code=code,
+            leader_only=False,
+            args=[],
+            kwargs={},
+        )
+
+        encoded = encode_add_transaction_data(
+            sender_address=sender,
+            recipient_address=recipient,
+            num_of_initial_validators=5,
+            max_rotations=3,
+            tx_data=tx_data,
+        )
+
+        decoded = decode_add_transaction_data(encoded)
+        assert decoded["sender_address"].lower() == sender.lower()
+        assert decoded["recipient_address"].lower() == recipient.lower()
+        assert decoded["num_of_initial_validators"] == 5
+        assert decoded["max_rotations"] == 3
+        assert (
+            Web3.to_bytes(hexstr=decoded["tx_data"]["decoded"]["code"]).decode("utf-8")
+            == code
+        )
+        assert decoded["tx_data"]["decoded"]["leader_only"] is False
+        assert decoded["tx_data"]["decoded"]["type"] == "deploy"


### PR DESCRIPTION
## Summary
- Replace consensus_main_abi.json with v0.5 IConsensusMain interface ABI (27 events, updated functions)
- Add `valid_until` parameter to `addTransaction` encoder (default 0 = no expiry)
- Add `valid_until` to decoder output for round-trip compatibility
- Update actions.py to pass `valid_until` through the encoding pipeline

## Test plan
- [ ] All 36 unit tests pass
- [ ] Verify `addTransaction` signature matches v0.5: `addTransaction(address,address,uint256,uint256,bytes,uint256)`
- [ ] Verify backward compatibility with default `valid_until=0`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transaction validity expiration support with a new `valid_until` parameter for encoding and decoding transaction data.
  * Updated consensus contract interface with restructured events and refined function signatures.

* **Chores**
  * Updated testnet WebSocket endpoint configuration to point to the genlayer testnet.

* **Tests**
  * Added comprehensive test coverage for consensus contract read-only operations and transaction data encoding/decoding validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->