### PR TITLE
ci: scope down release/sync-docs to dedicated GitHub Apps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,7 @@ jobs:
     name: Release and Upload Artifacts
     runs-on: ubuntu-latest
     needs: run-tests
+    environment: Publish
 
     concurrency:
       group: ${{ github.workflow }}-release-${{ github.ref_name }}
@@ -29,11 +30,11 @@ jobs:
 
     steps:
       - name: Setup | Get CI Bot Token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v3
         id: ci_bot_token
         with:
-          app_id: ${{ secrets.CI_BOT_APP_ID }}
-          private_key: ${{ secrets.CI_BOT_SECRET }}
+          client-id: ${{ vars.PUBLISH_CI_APP_CLIENT_ID }}
+          private-key: ${{ secrets.PUBLISH_CI_APP_KEY }}
 
       - name: Setup | Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -9,6 +9,7 @@ jobs:
   generate-and-sync:
     if: github.event_name != 'release' || !contains(github.event.release.tag_name, '-')
     runs-on: ubuntu-latest
+    environment: Sync-docs
     permissions:
       contents: read
     steps:
@@ -39,9 +40,9 @@ jobs:
 
       - name: Generate docs repo token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.DOCS_SYNC_APP_ID }}
+          client-id: ${{ vars.DOCS_SYNC_APP_CLIENT_ID }}
           private-key: ${{ secrets.DOCS_SYNC_APP_KEY }}
           repositories: genlayer-docs
 


### PR DESCRIPTION
## Summary

Reduce the attack surface of release & docs-sync workflows by replacing the shared, over-privileged CI bot with two dedicated, minimally scoped GitHub Apps gated behind protected environments. Mirrors the same change in [genlayer-testing-suite#78](https://github.com/genlayerlabs/genlayer-testing-suite/pull/78), [genlayer-cli#297](https://github.com/genlayerlabs/genlayer-cli/pull/297), and [genlayer-js#168](https://github.com/genlayerlabs/genlayer-js/pull/168).

- **`publish.yml`** — gate `release-and-upload` behind the `Publish` environment, switched from the archived `tibdex/github-app-token@v1` to the official `actions/create-github-app-token@v3`. Reads `vars.PUBLISH_CI_APP_CLIENT_ID` and `secrets.PUBLISH_CI_APP_KEY`.
- **`sync-docs.yml`** — bumped `actions/create-github-app-token` to `@v3`, switched to the explicit `client-id` parameter, gated behind the `Sync-docs` environment. Reads `vars.DOCS_SYNC_APP_CLIENT_ID` and `secrets.DOCS_SYNC_APP_KEY`. Cross-repo `repositories: genlayer-docs` token request is preserved.

Each App should be installed only on the repos it needs (Publish: this repo only; Sync-docs: this repo + `genlayer-docs`) with `Contents: Read & write` as the only permission.

## Pre-merge checklist (GitHub side)

- [ ] `Publish` environment exists with `PUBLISH_CI_APP_CLIENT_ID` (variable) and `PUBLISH_CI_APP_KEY` (secret)
- [ ] `Sync-docs` environment exists with `DOCS_SYNC_APP_CLIENT_ID` (variable) and `DOCS_SYNC_APP_KEY` (secret)
- [ ] Both Apps installed on `genlayer-py` (sync-docs App also on `genlayer-docs`) with only `Contents: Read & write`
- [ ] `Publish` App added to branch-protection bypass list on `main` (semantic-release pushes the version-bump commit + tag)
- [ ] `Sync-docs` environment "Deployment branches and tags" allows the `v*` tag pattern (otherwise `release: published` on a tag ref will be blocked)

## Test plan

- [ ] Land a `fix:` or `feat:` commit on `main` and confirm `publish.yml` mints a token, semantic-release pushes the version bump + tag, the GitHub Release is created, and the PyPI upload succeeds
- [ ] Confirm `sync-docs.yml` fires automatically on `release: published` and pushes the API-reference update to `genlayer-docs`
- [ ] Once verified, decommission the old shared CI App from this repo and rotate / revoke its secrets

## Notes

- `publish-to-pypi` job still reads `secrets.PYPI_API_TOKEN` from repo secrets directly (not gated behind an environment). Left as-is to keep this PR scoped, but moving it under `Publish` would add the same protection rules to PyPI uploads — happy to do that in a follow-up if desired.