### PR TITLE
fix: serialize fee payloads for studio estimates

### DIFF
--- a/genlayer_py/contracts/actions.py
+++ b/genlayer_py/contracts/actions.py
@@ -442,7 +442,22 @@ def _transaction_fees_to_rpc(
     }
     if normalized["fee_value"] is not None:
         rpc_fees["feeValue"] = normalized["fee_value"]
-    return rpc_fees
+    return _json_safe_rpc_value(rpc_fees)
+
+
+def _json_safe_rpc_value(value):
+    if isinstance(value, (bytes, bytearray)):
+        return "0x" + bytes(value).hex()
+    if isinstance(value, list):
+        return [_json_safe_rpc_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [_json_safe_rpc_value(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            key: _json_safe_rpc_value(item)
+            for key, item in value.items()
+        }
+    return value
 
 
 def _encode_submit_appeal_data(

--- a/genlayer_py/transactions/fees.py
+++ b/genlayer_py/transactions/fees.py
@@ -131,6 +131,7 @@ class TransactionFeeEstimate(TypedDict, total=False):
     fee_value: int
     policy: FeePolicyQuote
     observed: dict[str, int]
+    simulation: Any
 
 
 class SimulationFeeEstimateOptions(FeeEstimateOptions, total=False):
@@ -193,6 +194,7 @@ DEFAULT_PRICE_CAP_HEADROOM_BPS = 12_000
 DEFAULT_LEADER_TIMEUNITS_ALLOCATION = 100
 DEFAULT_VALIDATOR_TIMEUNITS_ALLOCATION = 200
 DEFAULT_TRANSACTION_EXECUTION_BUDGET_PER_ROUND = 500_000
+DEFAULT_PARENT_MESSAGE_RECEIPT_HEADROOM = 10_000
 MIN_RECEIPT_BYTES = 512
 DEFAULT_RECEIPT_SLOTS_CHANGED = 7
 DEFAULT_INTRINSIC_GAS = 21_000
@@ -967,6 +969,7 @@ def transaction_fee_estimate_from_studio_estimate(
         "feeValue": to_uint(fee_value, "recommendedPreset.feeValue"),
         "fee_value": to_uint(fee_value, "recommendedPreset.feeValue"),
         "policy": policy,
+        "simulation": simulation,
         "observed": observed_simulation_fee_usage(
             {"simulation": simulation},
             policy,
@@ -1058,17 +1061,38 @@ def build_estimated_fees_distribution(
         "priceCapHeadroomBps",
         DEFAULT_PRICE_CAP_HEADROOM_BPS,
     )
-    execution_budget_default = _default_execution_budget_per_round(policy)
+    base_execution_budget_default = _default_execution_budget_per_round(policy)
 
     total_message_fees = _get(options, "totalMessageFees", "total_message_fees")
     message_allocations = _get(options, "messageAllocations", "message_allocations")
+    normalized_message_allocations = (
+        normalize_message_fee_allocations(message_allocations)
+        if message_allocations is not None
+        else None
+    )
     if total_message_fees is None and message_allocations is not None:
         total_message_fees = sum(
             allocation["budget"]
-            for allocation in normalize_message_fee_allocations(message_allocations)
+            for allocation in normalized_message_allocations or []
             if allocation["messageType"] == int(MessageType.External)
             or allocation["parentIndex"] == MESSAGE_ALLOCATION_ROOT_PARENT_INDEX
         )
+    emits_messages = (
+        (
+            normalized_message_allocations is not None
+            and len(normalized_message_allocations) > 0
+        )
+        or (
+            total_message_fees is not None
+            and to_uint(total_message_fees, "totalMessageFees") > 0
+        )
+    )
+    execution_budget_default = (
+        base_execution_budget_default
+        + policy["receiptGasPrice"] * DEFAULT_PARENT_MESSAGE_RECEIPT_HEADROOM
+        if emits_messages
+        else base_execution_budget_default
+    )
 
     return create_fees_distribution(
         {

--- a/tests/unit/contracts/test_contract_actions.py
+++ b/tests/unit/contracts/test_contract_actions.py
@@ -28,6 +28,9 @@ from genlayer_py.transactions.fees import (
 )
 
 
+DEFAULT_PARENT_MESSAGE_RECEIPT_HEADROOM = 10_000
+
+
 ADD_TRANSACTION_ABI_V5 = [
     {
         "type": "function",
@@ -385,6 +388,10 @@ def test_simulate_write_contract_passes_fee_policy_and_value_to_sim_call():
         MessageType.Internal
     )
     assert request_params["fees"]["messageAllocations"][0]["budget"] == 5
+    assert (
+        request_params["fees"]["messageAllocations"][0]["callKey"]
+        == "0x" + "00" * 32
+    )
 
 
 def test_encode_add_transaction_uses_v5_signature_when_abi_has_5_inputs():
@@ -584,11 +591,40 @@ def test_build_estimated_fees_distribution_adds_caps_and_message_bucket():
 
     assert distribution["leaderTimeunitsAllocation"] == 100
     assert distribution["validatorTimeunitsAllocation"] == 200
-    assert distribution["executionBudgetPerRound"] == 500_000
+    assert distribution["executionBudgetPerRound"] == (
+        500_000 + 30 * DEFAULT_PARENT_MESSAGE_RECEIPT_HEADROOM
+    )
     assert distribution["totalMessageFees"] == 80
     assert distribution["maxPriceGenPerTimeUnit"] == 12
     assert distribution["storageFeeMaxGasPrice"] == 24
     assert distribution["receiptFeeMaxGasPrice"] == 36
+
+
+def test_build_estimated_fees_distribution_preserves_explicit_execution_budget_with_messages():
+    policy = {
+        "enabled": True,
+        "genPerTimeUnit": 10,
+        "storageUnitPrice": 20,
+        "receiptGasPrice": 30,
+        "executionBudgetFloor": 1_234,
+    }
+
+    distribution = build_estimated_fees_distribution(
+        {
+            "executionBudgetPerRound": 42,
+            "messageAllocations": [
+                {
+                    "messageType": MessageType.Internal,
+                    "recipient": RECIPIENT,
+                    "budget": 50,
+                    "feeParams": "0x1234",
+                },
+            ],
+        },
+        policy,
+    )
+
+    assert distribution["executionBudgetPerRound"] == 42
 
 
 def test_calculate_local_round_fees_matches_consensus_initial_round():
@@ -702,7 +738,10 @@ def test_estimate_transaction_fees_derives_message_bucket_from_allocations():
     )
 
     assert estimate["distribution"]["totalMessageFees"] == 80
-    assert estimate["feeValue"] == 9_196_840
+    assert estimate["distribution"]["executionBudgetPerRound"] == (
+        9_185_760 + 30 * DEFAULT_PARENT_MESSAGE_RECEIPT_HEADROOM
+    )
+    assert estimate["feeValue"] == 9_496_840
     assert estimate["messageAllocations"] == message_allocations
     assert estimate["message_allocations"] == message_allocations
 
@@ -882,12 +921,18 @@ def test_estimate_transaction_fees_for_write_uses_studio_estimate_rpc():
     )
     request_params = sim_call.kwargs["params"][0]
     assert request_params["value"] == hex(7)
-    assert request_params["fees"]["feeValue"] == 511_110
+    assert request_params["fees"]["feeValue"] == 521_110
     assert request_params["fees"]["distribution"]["totalMessageFees"] == 110
     assert request_params["fees"]["messageAllocations"][0]["budget"] == 110
+    assert (
+        request_params["fees"]["messageAllocations"][0]["callKey"]
+        == "0x" + "00" * 32
+    )
     assert estimate["observed"]["recommendedExecutionBudgetPerRound"] == 602_117
     assert estimate["observed"]["messageFeeBudget"] == 110
     assert estimate["observed"]["messageFeeConsumed"] == 50
+    assert estimate["simulation"]["feeAccounting"]["message_fee_budget"] == "110"
+    assert estimate["simulation"]["feeReport"]["totalEstimatedFee"] == "501664"
     assert estimate["distribution"]["executionBudgetPerRound"] == 700_000
     assert estimate["distribution"]["totalMessageFees"] == 110
     assert estimate["messageAllocations"][0]["budget"] == 110


### PR DESCRIPTION
## Summary

- serializes nested bytes in fee payloads before sending Studio estimate RPC requests
- preserves simulation data on Python fee estimates for E2E assertions
- adds message receipt headroom coverage and focused unit assertions

## Verification

- `uv run pytest tests/unit/contracts/test_contract_actions.py --disable-warnings -q`

This fixes the current v0.6 Studio tooling run failure where `genlayer-py` fails `051_fee_high_budget_presets.feature` with `TypeError: Object of type bytes is not JSON serializable`.