### PR TITLE
feat(fees)!: estimation correctness, wait-for-decided semantics, v0.6 parity with genlayer-js

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,9 @@
 name: Tests
 
 on:
+  push:
+    branches:
+      - 'v*-dev'
   workflow_call:
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review]

--- a/genlayer_py/chains/testnet_asimov.py
+++ b/genlayer_py/chains/testnet_asimov.py
@@ -1,4 +1,4 @@
-from genlayer_py.types import GenLayerChain, NativeCurrency
+from genlayer_py.types import GenLayerChain, NativeCurrency, SimpleContractInfo
 from genlayer_py.consensus.abi import CONSENSUS_MAIN_ABI, CONSENSUS_DATA_ABI
 
 
@@ -15,6 +15,103 @@ CONSENSUS_DATA_CONTRACT = {
     "address": "0x0D9d1d74d72Fa5eB94bcf746C8FCcb312a722c9B",
     "abi": CONSENSUS_DATA_ABI,
     "bytecode": "",
+}
+
+FEE_MANAGER_CONTRACT: SimpleContractInfo = {
+    "address": "0x21737AA4bea8FF12E202BF1BAB23751A95617533",
+    "abi": [
+        {
+            "type": "function",
+            "name": "calculateMinAppealBond",
+            "stateMutability": "view",
+            "inputs": [
+                {"name": "_txId", "type": "bytes32"},
+                {"name": "_round", "type": "uint256"},
+                {"name": "_status", "type": "uint8"},
+            ],
+            "outputs": [{"name": "totalFeesToPay", "type": "uint256"}],
+        },
+    ],
+}
+
+ROUNDS_STORAGE_CONTRACT: SimpleContractInfo = {
+    "address": "0x1F595c0D549DE0812F127508ea1039636CFA62Cc",
+    "abi": [
+        {
+            "type": "function",
+            "name": "getRoundNumber",
+            "stateMutability": "view",
+            "inputs": [{"name": "txId", "type": "bytes32"}],
+            "outputs": [{"name": "", "type": "uint256"}],
+        },
+        {
+            "type": "function",
+            "name": "getRoundData",
+            "stateMutability": "view",
+            "inputs": [
+                {"name": "txId", "type": "bytes32"},
+                {"name": "round", "type": "uint256"},
+            ],
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "tuple",
+                    "components": [
+                        {"name": "round", "type": "uint256"},
+                        {"name": "leaderIndex", "type": "uint256"},
+                        {"name": "votesCommitted", "type": "uint256"},
+                        {"name": "votesRevealed", "type": "uint256"},
+                        {"name": "appealBond", "type": "uint256"},
+                        {"name": "rotationsLeft", "type": "uint256"},
+                        {"name": "result", "type": "uint8"},
+                        {"name": "roundValidators", "type": "address[]"},
+                        {"name": "validatorVotes", "type": "uint8[]"},
+                        {"name": "validatorVotesHash", "type": "bytes32[]"},
+                        {"name": "validatorResultHash", "type": "bytes32[]"},
+                    ],
+                }
+            ],
+        },
+        {
+            "type": "function",
+            "name": "getLastRoundData",
+            "stateMutability": "view",
+            "inputs": [{"name": "txId", "type": "bytes32"}],
+            "outputs": [
+                {"name": "round", "type": "uint256"},
+                {
+                    "name": "roundData",
+                    "type": "tuple",
+                    "components": [
+                        {"name": "round", "type": "uint256"},
+                        {"name": "leaderIndex", "type": "uint256"},
+                        {"name": "votesCommitted", "type": "uint256"},
+                        {"name": "votesRevealed", "type": "uint256"},
+                        {"name": "appealBond", "type": "uint256"},
+                        {"name": "rotationsLeft", "type": "uint256"},
+                        {"name": "result", "type": "uint8"},
+                        {"name": "roundValidators", "type": "address[]"},
+                        {"name": "validatorVotes", "type": "uint8[]"},
+                        {"name": "validatorVotesHash", "type": "bytes32[]"},
+                        {"name": "validatorResultHash", "type": "bytes32[]"},
+                    ],
+                },
+            ],
+        },
+    ],
+}
+
+APPEALS_CONTRACT: SimpleContractInfo = {
+    "address": "0x0F739Dd8f5322b9547c7d19a9621BC2ac8DF4089",
+    "abi": [
+        {
+            "type": "function",
+            "name": "canAppeal",
+            "stateMutability": "view",
+            "inputs": [{"name": "_txId", "type": "bytes32"}],
+            "outputs": [{"name": "", "type": "bool"}],
+        },
+    ],
 }
 
 
@@ -34,9 +131,9 @@ testnet_asimov: GenLayerChain = GenLayerChain(
     testnet=True,
     consensus_main_contract=CONSENSUS_MAIN_CONTRACT,
     consensus_data_contract=CONSENSUS_DATA_CONTRACT,
-    fee_manager_contract=None,
-    rounds_storage_contract=None,
-    appeals_contract=None,
+    fee_manager_contract=FEE_MANAGER_CONTRACT,
+    rounds_storage_contract=ROUNDS_STORAGE_CONTRACT,
+    appeals_contract=APPEALS_CONTRACT,
     staking_contract=None,
     default_number_of_initial_validators=5,
     default_consensus_max_rotations=3,

--- a/genlayer_py/client/genlayer_client.py
+++ b/genlayer_py/client/genlayer_client.py
@@ -4,7 +4,7 @@ from web3.types import Nonce, BlockIdentifier, ENS, _Hash32
 from eth_typing import Address, ChecksumAddress, HexStr
 from eth_account.signers.local import LocalAccount
 from hexbytes import HexBytes
-from typing import AnyStr
+from typing import AnyStr, Literal
 from genlayer_py.types import (
     GenLayerChain,
     TransactionStatus,
@@ -302,8 +302,8 @@ class GenLayerClient(Eth):
         self,
         transaction_id: HexStr,
         distribution: FeesDistributionInput,
+        value: int,
         account: Optional[LocalAccount] = None,
-        value: int = 0,
     ) -> HexStr:
         """Deposits additional fee budget for an existing consensus transaction."""
         return top_up_fees(
@@ -319,7 +319,7 @@ class GenLayerClient(Eth):
         transaction_id: HexStr,
         distribution: FeesDistributionInput,
         account: Optional[LocalAccount] = None,
-        value: int = 0,
+        value: Optional[int] = None,
     ) -> HexStr:
         """Deposits appeal fee budget and submits an appeal in one consensus call."""
         return top_up_and_submit_appeal(
@@ -334,7 +334,8 @@ class GenLayerClient(Eth):
     def wait_for_transaction_receipt(
         self,
         transaction_hash: _Hash32,
-        status: TransactionStatus = TransactionStatus.ACCEPTED,
+        status: Optional[TransactionStatus] = None,
+        wait_until: Optional[Literal["decided", "finalized"]] = None,
         interval: int = transaction_config.wait_interval,
         retries: int = transaction_config.retries,
         full_transaction: bool = False,
@@ -344,6 +345,7 @@ class GenLayerClient(Eth):
             self=self,
             transaction_hash=transaction_hash,
             status=status,
+            wait_until=wait_until,
             interval=interval,
             retries=retries,
             full_transaction=full_transaction,
@@ -375,7 +377,7 @@ class GenLayerClient(Eth):
         self,
         transaction_id: HexStr,
         account: Optional[LocalAccount] = None,
-        value: int = 0,
+        value: Optional[int] = None,
     ):
         """Appeals a consensus transaction to trigger a new round of validation.
         Returns the original transaction_id (appeals operate on the same tx)."""

--- a/genlayer_py/contracts/actions.py
+++ b/genlayer_py/contracts/actions.py
@@ -24,6 +24,13 @@ from genlayer_py.transactions.fees import (
     FeesDistributionInput,
     FeesDistribution,
     FEES_DISTRIBUTION_ABI_TYPE,
+    DEFAULT_BOOTLOADER_OVERHEAD,
+    DEFAULT_CALLDATA_GAS_PER_BYTE,
+    DEFAULT_FIXED_PROPOSE_RECEIPT_GAS,
+    DEFAULT_GAS_PER_CHANGED_SLOT,
+    DEFAULT_INTRINSIC_GAS,
+    DEFAULT_RECEIPT_SLOTS_CHANGED,
+    MIN_RECEIPT_BYTES,
     NormalizedTransactionFees,
     SimulationFeeEstimateOptions,
     TransactionFeeEstimate,
@@ -214,7 +221,7 @@ def appeal_transaction(
     self: GenLayerClient,
     transaction_id: HexStr,
     account: Optional[LocalAccount] = None,
-    value: int = 0,
+    value: Optional[int] = None,
 ) -> HexStr:
     """Appeals a consensus transaction. Returns the original transaction_id.
 
@@ -226,6 +233,7 @@ def appeal_transaction(
         raise GenLayerError("No account set.")
     if self.chain.consensus_main_contract is None:
         raise GenLayerError("Consensus main contract not configured.")
+    resolved_value = _resolve_appeal_value(self, transaction_id, value)
 
     encoded_data = _encode_submit_appeal_data(self=self, transaction_id=transaction_id)
 
@@ -233,7 +241,7 @@ def appeal_transaction(
         self=self,
         encoded_data=encoded_data,
         sender_account=sender_account,
-        value=value,
+        value=resolved_value,
         operation_name="Appeal",
     )
 
@@ -244,8 +252,8 @@ def top_up_fees(
     self: GenLayerClient,
     transaction_id: HexStr,
     distribution: FeesDistributionInput,
+    value: int,
     account: Optional[LocalAccount] = None,
-    value: int = 0,
 ) -> HexStr:
     """Deposits additional fee budget for an existing consensus transaction.
 
@@ -273,13 +281,14 @@ def top_up_and_submit_appeal(
     transaction_id: HexStr,
     distribution: FeesDistributionInput,
     account: Optional[LocalAccount] = None,
-    value: int = 0,
+    value: Optional[int] = None,
 ) -> HexStr:
     """Deposits appeal fee budget and submits an appeal in one consensus call.
 
     Returns the original GenLayer transaction id, matching appeal_transaction.
     """
     sender_account = account if account is not None else self.local_account
+    resolved_value = _resolve_appeal_value(self, transaction_id, value)
     encoded_data = _encode_fee_management_data(
         self=self,
         function_name="topUpAndSubmitAppeal",
@@ -290,7 +299,7 @@ def top_up_and_submit_appeal(
         self=self,
         encoded_data=encoded_data,
         sender_account=sender_account,
-        value=value,
+        value=resolved_value,
         operation_name="Top up and submit appeal",
     )
     return transaction_id
@@ -375,6 +384,20 @@ def get_min_appeal_bond(
     )
     tx_bytes = _to_bytes32(self, transaction_id)
     return fee_contract.functions.calculateMinAppealBond(tx_bytes, round_number, tx_status).call()
+
+
+def _resolve_appeal_value(
+    self: GenLayerClient,
+    transaction_id: HexStr,
+    value: Optional[int],
+) -> int:
+    if value is not None:
+        return value
+    if self.chain.fee_manager_contract is None or self.chain.rounds_storage_contract is None:
+        raise GenLayerError(
+            "Cannot auto-resolve appeal bond: fee_manager_contract/rounds_storage_contract not configured for this chain."
+        )
+    return get_min_appeal_bond(self, transaction_id)
 
 
 def _to_bytes32(self: GenLayerClient, hex_str: HexStr) -> bytes:
@@ -597,20 +620,37 @@ def get_current_fee_policy(self: GenLayerClient) -> FeePolicyQuote:
         )
         gen_per_time_unit = fee_manager_contract.functions.GENPerTimeUnit().call()
         storage_unit_price = fee_manager_contract.functions.storageUnitPrice().call()
-        receipt_gas_price = fee_manager_contract.functions.quoteGasPrice().call()
+        quoted_receipt_gas_price = fee_manager_contract.functions.quoteGasPrice().call()
         execution_budget_floor = (
             fee_manager_contract.functions.messageFeeParamsBudgetFloor().call()
         )
+        enabled = (
+            gen_per_time_unit > 0
+            or storage_unit_price > 0
+            or quoted_receipt_gas_price > 0
+        )
+        network_receipt_gas_price = self.w3.eth.gas_price if enabled else 0
+        receipt_gas_price = max(quoted_receipt_gas_price, network_receipt_gas_price)
+        if enabled and receipt_gas_price == 0:
+            raise GenLayerError(
+                "receipt gas price quoted as zero; refusing to build a zero price cap"
+            )
+        local_execution_budget_floor = receipt_gas_price * (
+            DEFAULT_FIXED_PROPOSE_RECEIPT_GAS
+            + DEFAULT_INTRINSIC_GAS
+            + DEFAULT_BOOTLOADER_OVERHEAD
+            + (MIN_RECEIPT_BYTES * DEFAULT_CALLDATA_GAS_PER_BYTE)
+            + (DEFAULT_RECEIPT_SLOTS_CHANGED * DEFAULT_GAS_PER_CHANGED_SLOT)
+        )
         return {
-            "enabled": (
-                gen_per_time_unit > 0
-                or storage_unit_price > 0
-                or receipt_gas_price > 0
-            ),
+            "enabled": enabled,
             "genPerTimeUnit": gen_per_time_unit,
             "storageUnitPrice": storage_unit_price,
             "receiptGasPrice": receipt_gas_price,
-            "executionBudgetFloor": execution_budget_floor,
+            "executionBudgetFloor": max(
+                execution_budget_floor,
+                local_execution_budget_floor,
+            ),
         }
 
     try:
@@ -920,6 +960,46 @@ def _prepare_transaction(
     return transaction
 
 
+KNOWN_REVERT_SELECTOR_NAMES = {
+    "0x8d53e553": "InsufficientFees",
+    "0xb4132db3": "MaxPriceExceeded",
+    "0x57df8523": "ExecutionBudgetExceeded",
+    "0x305e533c": "BudgetTooLow",
+    "0xa70732ee": "RollupBudgetBelowFloor",
+    "0x632be5a1": "FeeValueMustBeNonZero",
+}
+
+
+def _format_rpc_error(error: Exception) -> str:
+    parts = [str(error)]
+    for attr in ("message", "data"):
+        value = getattr(error, attr, None)
+        if isinstance(value, str) and value.strip():
+            parts.append(value)
+    args = getattr(error, "args", ())
+    for arg in args:
+        if isinstance(arg, dict):
+            for key in ("message", "data", "details", "shortMessage"):
+                value = arg.get(key)
+                if isinstance(value, str) and value.strip():
+                    parts.append(value)
+        elif isinstance(arg, str) and arg.strip():
+            parts.append(arg)
+
+    text = " ".join(dict.fromkeys(parts))
+    selector_name = next(
+        (
+            name
+            for selector, name in KNOWN_REVERT_SELECTOR_NAMES.items()
+            if selector in text
+        ),
+        None,
+    )
+    if selector_name and selector_name not in text:
+        return f"{text} ({selector_name})"
+    return text
+
+
 def _send_consensus_call(
     self: GenLayerClient,
     encoded_data: HexStr,
@@ -934,18 +1014,21 @@ def _send_consensus_call(
     if self.chain.consensus_main_contract is None:
         raise GenLayerError("Consensus main contract not configured.")
 
-    transaction = _prepare_transaction(
-        self=self,
-        sender=sender_account.address,
-        recipient=self.chain.consensus_main_contract["address"],
-        data=encoded_data,
-        value=value,
-    )
-    signed_transaction = sender_account.sign_transaction(transaction)
-    serialized_transaction = self.w3.to_hex(signed_transaction.raw_transaction)
-    tx_hash = self.provider.make_request(
-        method="eth_sendRawTransaction", params=[serialized_transaction]
-    )["result"]
+    try:
+        transaction = _prepare_transaction(
+            self=self,
+            sender=sender_account.address,
+            recipient=self.chain.consensus_main_contract["address"],
+            data=encoded_data,
+            value=value,
+        )
+        signed_transaction = sender_account.sign_transaction(transaction)
+        serialized_transaction = self.w3.to_hex(signed_transaction.raw_transaction)
+        tx_hash = self.provider.make_request(
+            method="eth_sendRawTransaction", params=[serialized_transaction]
+        )["result"]
+    except Exception as exc:
+        raise GenLayerError(f"{operation_name} failed: {_format_rpc_error(exc)}") from exc
     if self.chain.id == localnet.id:
         return tx_hash
 
@@ -974,21 +1057,24 @@ def _send_transaction(
             f"Consensus main contract address not found in chain config for \"{self.chain.name}\".",
         )
 
-    transaction = _prepare_transaction(
-        self=self,
-        sender=sender_account.address,
-        recipient=self.chain.consensus_main_contract["address"],
-        data=encoded_data,
-        value=value,
-    )
-    signed_transaction = sender_account.sign_transaction(transaction)
-    serialized_transaction = self.w3.to_hex(signed_transaction.raw_transaction)
-    params = [serialized_transaction]
-    if sim_config is not None:
-        params.append(sim_config)
-    tx_hash = self.provider.make_request(
-        method="eth_sendRawTransaction", params=params
-    )["result"]
+    try:
+        transaction = _prepare_transaction(
+            self=self,
+            sender=sender_account.address,
+            recipient=self.chain.consensus_main_contract["address"],
+            data=encoded_data,
+            value=value,
+        )
+        signed_transaction = sender_account.sign_transaction(transaction)
+        serialized_transaction = self.w3.to_hex(signed_transaction.raw_transaction)
+        params = [serialized_transaction]
+        if sim_config is not None:
+            params.append(sim_config)
+        tx_hash = self.provider.make_request(
+            method="eth_sendRawTransaction", params=params
+        )["result"]
+    except Exception as exc:
+        raise GenLayerError(f"Transaction failed: {_format_rpc_error(exc)}") from exc
     tx_receipt = self.w3.eth.wait_for_transaction_receipt(tx_hash)
 
     if tx_receipt.status != 1:

--- a/genlayer_py/transactions/__init__.py
+++ b/genlayer_py/transactions/__init__.py
@@ -2,6 +2,7 @@ from .fees import (
     CALL_KEY_DEPLOY,
     CALL_KEY_UNNAMED,
     CALL_KEY_WILDCARD,
+    DEPLOY_CALL_KEY,
     MESSAGE_ALLOCATION_ROOT_PARENT_INDEX,
     DEFAULT_FEES_DISTRIBUTION,
     MessageType,
@@ -9,16 +10,24 @@ from .fees import (
     calculate_local_round_fees,
     create_fees_distribution,
     derive_external_message_call_key,
+    deploy_call_key,
     derive_internal_message_call_key,
     encode_external_message_fee_params,
     encode_internal_message_fee_params,
     extract_studio_fee_policy,
 )
 
+
+def is_successful(transaction):
+    from .actions import is_successful as _is_successful
+
+    return _is_successful(transaction)
+
 __all__ = [
     "CALL_KEY_DEPLOY",
     "CALL_KEY_UNNAMED",
     "CALL_KEY_WILDCARD",
+    "DEPLOY_CALL_KEY",
     "MESSAGE_ALLOCATION_ROOT_PARENT_INDEX",
     "DEFAULT_FEES_DISTRIBUTION",
     "MessageType",
@@ -26,8 +35,10 @@ __all__ = [
     "calculate_local_round_fees",
     "create_fees_distribution",
     "derive_external_message_call_key",
+    "deploy_call_key",
     "derive_internal_message_call_key",
     "encode_external_message_fee_params",
     "encode_internal_message_fee_params",
     "extract_studio_fee_policy",
+    "is_successful",
 ]

--- a/genlayer_py/transactions/actions.py
+++ b/genlayer_py/transactions/actions.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from genlayer_py.logging import logger
 import json
-from typing import Any, Dict, List
+import warnings
+from typing import Any, Dict, List, Literal, Optional
 from web3 import Web3
 from web3.types import _Hash32
 from eth_typing import HexStr
@@ -11,6 +12,8 @@ from web3.logs import DISCARD
 from genlayer_py.config import transaction_config
 from genlayer_py.types import (
     TransactionStatus,
+    ExecutionResult,
+    EXECUTION_RESULT_NUMBER_TO_NAME,
     TRANSACTION_STATUS_NAME_TO_NUMBER,
     TRANSACTION_STATUS_NUMBER_TO_NAME,
     is_decided_state,
@@ -66,40 +69,129 @@ if TYPE_CHECKING:
     from genlayer_py.client import GenLayerClient
 
 
+_did_warn_wait_for_transaction_receipt_status = False
+
+
+def _warn_deprecated_receipt_status() -> None:
+    global _did_warn_wait_for_transaction_receipt_status
+    if _did_warn_wait_for_transaction_receipt_status:
+        return
+    _did_warn_wait_for_transaction_receipt_status = True
+    warnings.warn(
+        "wait_for_transaction_receipt(status=...) is deprecated; use "
+        "wait_until='decided' or wait_until='finalized' instead.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
+def _resolve_wait_target(
+    status: Optional[TransactionStatus],
+    wait_until: Optional[Literal["decided", "finalized"]],
+) -> dict:
+    if wait_until is not None:
+        if wait_until not in ("decided", "finalized"):
+            raise ValueError("wait_until must be 'decided' or 'finalized'.")
+        return {"wait_until": wait_until, "legacy_status": None, "label": wait_until}
+    if status is None:
+        return {"wait_until": "decided", "legacy_status": None, "label": "decided"}
+
+    _warn_deprecated_receipt_status()
+    if status == TransactionStatus.ACCEPTED:
+        return {"wait_until": "decided", "legacy_status": None, "label": "decided"}
+    if status == TransactionStatus.FINALIZED:
+        return {"wait_until": "finalized", "legacy_status": None, "label": "finalized"}
+    return {"wait_until": None, "legacy_status": status, "label": status.value}
+
+
+def _has_reached_wait_target(transaction_status: str, target: dict) -> bool:
+    if target["wait_until"] == "decided":
+        return is_decided_state(transaction_status)
+    if target["wait_until"] == "finalized":
+        return transaction_status == TRANSACTION_STATUS_NAME_TO_NUMBER[
+            TransactionStatus.FINALIZED
+        ]
+    legacy_status = target["legacy_status"]
+    return (
+        legacy_status is not None
+        and transaction_status == TRANSACTION_STATUS_NAME_TO_NUMBER[legacy_status]
+    )
+
+
+def _normalize_status_name(value: Any) -> Optional[TransactionStatus]:
+    if isinstance(value, TransactionStatus):
+        return value
+    if isinstance(value, str):
+        if value in TransactionStatus._value2member_map_:
+            return TransactionStatus(value)
+        return TRANSACTION_STATUS_NUMBER_TO_NAME.get(value)
+    if value is None:
+        return None
+    return TRANSACTION_STATUS_NUMBER_TO_NAME.get(str(value))
+
+
+def _normalize_execution_result_name(value: Any) -> Optional[ExecutionResult]:
+    if isinstance(value, ExecutionResult):
+        return value
+    if isinstance(value, str) and value in ExecutionResult._value2member_map_:
+        return ExecutionResult(value)
+    if value is None:
+        return None
+    return EXECUTION_RESULT_NUMBER_TO_NAME.get(str(value))
+
+
+def is_successful(transaction: GenLayerTransaction) -> bool:
+    status_name = _normalize_status_name(
+        transaction.get("status_name", transaction.get("status"))
+    )
+    execution_result_name = _normalize_execution_result_name(
+        transaction.get(
+            "tx_execution_result_name",
+            transaction.get("tx_execution_result"),
+        )
+    )
+    return (
+        status_name in (TransactionStatus.ACCEPTED, TransactionStatus.FINALIZED)
+        and execution_result_name == ExecutionResult.FINISHED_WITH_RETURN
+    )
+
+
 def wait_for_transaction_receipt(
     self: GenLayerClient,
     transaction_hash: _Hash32,
-    status: TransactionStatus = TransactionStatus.ACCEPTED,
+    status: Optional[TransactionStatus] = None,
+    wait_until: Optional[Literal["decided", "finalized"]] = None,
     interval: int = transaction_config.wait_interval,
     retries: int = transaction_config.retries,
     full_transaction: bool = False,
 ) -> GenLayerTransaction:
 
     attempts = 0
+    target = _resolve_wait_target(status, wait_until)
+    transaction = None
+    last_status = None
     while attempts < retries:
         transaction = self.get_transaction(transaction_hash=transaction_hash)
         if transaction is None:
             raise GenLayerError(f"Transaction {transaction_hash} not found")
         transaction_status = str(transaction["status"])
-        last_status = TRANSACTION_STATUS_NUMBER_TO_NAME[transaction_status]
-        finalized_status = TRANSACTION_STATUS_NAME_TO_NUMBER[
-            TransactionStatus.FINALIZED
-        ]
-        requested_status = TRANSACTION_STATUS_NAME_TO_NUMBER[status]
+        last_status = TRANSACTION_STATUS_NUMBER_TO_NAME.get(transaction_status)
 
-        if transaction_status == requested_status or (
-            status == TransactionStatus.ACCEPTED
-            and is_decided_state(transaction_status)
-        ):
+        if _has_reached_wait_target(transaction_status, target):
             if not full_transaction:
                 return _simplify_transaction_receipt(transaction)
             return transaction
         time.sleep(interval / 1000)
         attempts += 1
+    last_status_label = (
+        last_status.value
+        if isinstance(last_status, TransactionStatus)
+        else str(transaction["status"]) if transaction else "<unknown>"
+    )
     raise GenLayerError(
-        f"Transaction {transaction_hash} did not reach desired status '{status.value}' after {retries} attempts "
+        f"Transaction {transaction_hash} did not reach desired status '{target['label']}' after {retries} attempts "
         f"(polling every {interval}ms for a total of {retries * interval / 1000:.1f}s). "
-        f"Last observed status: '{last_status.value}'. "
+        f"Last observed status: '{last_status_label}'. "
         f"This may indicate the transaction is still processing, or the network is experiencing delays. "
         f"Consider increasing 'retries' or 'interval' parameters.\n"
         f"Transaction object simplified: {json.dumps(_simplify_transaction_receipt(transaction), indent=2, default=str)}"

--- a/genlayer_py/transactions/fees.py
+++ b/genlayer_py/transactions/fees.py
@@ -156,7 +156,8 @@ class NormalizedTransactionFees(TypedDict):
 MESSAGE_ALLOCATION_ROOT_PARENT_INDEX = (1 << 256) - 1
 CALL_KEY_WILDCARD = b"\x00" * 32
 CALL_KEY_UNNAMED = HexStr("0x" + ("0" * 64))
-CALL_KEY_DEPLOY = CALL_KEY_UNNAMED
+DEPLOY_CALL_KEY = HexStr("0x" + ("0" * 62) + "01")
+CALL_KEY_DEPLOY = DEPLOY_CALL_KEY
 
 FEES_DISTRIBUTION_ABI_TYPE = (
     "(uint256,uint256,uint256,uint256,uint256,uint256,uint256[],uint256,uint256,uint256)"
@@ -194,6 +195,8 @@ DEFAULT_PRICE_CAP_HEADROOM_BPS = 12_000
 DEFAULT_LEADER_TIMEUNITS_ALLOCATION = 100
 DEFAULT_VALIDATOR_TIMEUNITS_ALLOCATION = 200
 DEFAULT_TRANSACTION_EXECUTION_BUDGET_PER_ROUND = 500_000
+# Provisional heuristic sized ~20x observed dev-env consumption (~5M gas-equivalent).
+# TODO(data): replace with telemetry-derived default (p99 x margin) once fee consumption telemetry is collected.
 DEFAULT_TRANSACTION_EXECUTION_GAS = 100_000_000
 DEFAULT_PARENT_MESSAGE_RECEIPT_HEADROOM = 10_000
 MIN_RECEIPT_BYTES = 512
@@ -201,8 +204,11 @@ DEFAULT_RECEIPT_SLOTS_CHANGED = 7
 DEFAULT_INTRINSIC_GAS = 21_000
 DEFAULT_BOOTLOADER_OVERHEAD = 60_000
 DEFAULT_FIXED_PROPOSE_RECEIPT_GAS = 210_000
+DEFAULT_FIXED_MESSAGE_REVEAL_GAS = 100_000
 DEFAULT_GAS_PER_CHANGED_SLOT = 1_000
 DEFAULT_CALLDATA_GAS_PER_BYTE = 16
+DEFAULT_MESSAGE_REVEAL_LENGTH_SLOTS = 32
+DEFAULT_NONDET_OUTPUT_LENGTH_BYTES = 32
 ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 VALIDATORS_PER_ROUND = [
@@ -306,6 +312,10 @@ def derive_external_message_call_key(
     if len(calldata) < 4:
         return CALL_KEY_UNNAMED
     return _bytes_to_padded_call_key(calldata[:4])
+
+
+def deploy_call_key() -> HexStr:
+    return DEPLOY_CALL_KEY
 
 
 def _normalize_message_type(value: Union[MessageType, int, str]) -> int:
@@ -658,6 +668,10 @@ def extract_studio_fee_policy(config: Any) -> FeePolicyQuote:
         policy.get("fixedProposeReceiptGas", DEFAULT_FIXED_PROPOSE_RECEIPT_GAS),
         "policy.fixedProposeReceiptGas",
     )
+    fixed_message_reveal_gas = _int_from_unknown(
+        policy.get("fixedMessageRevealGas", DEFAULT_FIXED_MESSAGE_REVEAL_GAS),
+        "policy.fixedMessageRevealGas",
+    )
     explicit_budget_floor = policy.get(
         "messageFeeParamsBudgetFloor",
         config.get("messageFeeParamsBudgetFloor"),
@@ -673,8 +687,12 @@ def extract_studio_fee_policy(config: Any) -> FeePolicyQuote:
             fixed_propose_receipt_gas
             + intrinsic_gas
             + bootloader_overhead
-            + (MIN_RECEIPT_BYTES * calldata_gas_per_byte)
             + (DEFAULT_RECEIPT_SLOTS_CHANGED * gas_per_changed_slot)
+            + fixed_message_reveal_gas
+            + intrinsic_gas
+            + bootloader_overhead
+            + (DEFAULT_MESSAGE_REVEAL_LENGTH_SLOTS * gas_per_changed_slot)
+            + (DEFAULT_NONDET_OUTPUT_LENGTH_BYTES * calldata_gas_per_byte)
         )
     )
 
@@ -860,7 +878,7 @@ def observed_simulation_fee_usage(
     observed_execution_budget = execution_fee_consumed + execution_fee_report_total
     recommended_execution_budget = (
         max(
-            _default_execution_budget_per_round(policy),
+            policy["executionBudgetFloor"],
             _with_cap_headroom(observed_execution_budget, execution_headroom_bps),
         )
         if observed_execution_budget > 0

--- a/genlayer_py/types/transactions.py
+++ b/genlayer_py/types/transactions.py
@@ -27,6 +27,7 @@ class TransactionStatus(str, Enum):
     READY_TO_FINALIZE = "READY_TO_FINALIZE"
     VALIDATORS_TIMEOUT = "VALIDATORS_TIMEOUT"
     LEADER_TIMEOUT = "LEADER_TIMEOUT"
+    LEADER_REVEALING = "LEADER_REVEALING"
 
 
 TRANSACTION_STATUS_NUMBER_TO_NAME = {
@@ -44,6 +45,7 @@ TRANSACTION_STATUS_NUMBER_TO_NAME = {
     "11": TransactionStatus.READY_TO_FINALIZE,
     "12": TransactionStatus.VALIDATORS_TIMEOUT,
     "13": TransactionStatus.LEADER_TIMEOUT,
+    "14": TransactionStatus.LEADER_REVEALING,
 }
 
 TRANSACTION_STATUS_NAME_TO_NUMBER = {
@@ -61,6 +63,7 @@ TRANSACTION_STATUS_NAME_TO_NUMBER = {
     TransactionStatus.READY_TO_FINALIZE: "11",
     TransactionStatus.VALIDATORS_TIMEOUT: "12",
     TransactionStatus.LEADER_TIMEOUT: "13",
+    TransactionStatus.LEADER_REVEALING: "14",
 }
 
 DECIDED_STATES = [
@@ -86,29 +89,26 @@ class TransactionResult(str, Enum):
     NO_MAJORITY = "NO_MAJORITY"
     MAJORITY_AGREE = "MAJORITY_AGREE"
     MAJORITY_DISAGREE = "MAJORITY_DISAGREE"
+    MAJORITY_TIMEOUT = "MAJORITY_TIMEOUT"
 
 
 TRANSACTION_RESULT_NUMBER_TO_NAME = {
     "0": TransactionResult.IDLE,
-    "1": TransactionResult.AGREE,
-    "2": TransactionResult.DISAGREE,
-    "3": TransactionResult.TIMEOUT,
+    "1": TransactionResult.MAJORITY_AGREE,
+    "2": TransactionResult.MAJORITY_DISAGREE,
+    "3": TransactionResult.MAJORITY_TIMEOUT,
     "4": TransactionResult.DETERMINISTIC_VIOLATION,
     "5": TransactionResult.NO_MAJORITY,
-    "6": TransactionResult.MAJORITY_AGREE,
-    "7": TransactionResult.MAJORITY_DISAGREE,
 }
 
 
 TRANSACTION_RESULT_NAME_TO_NUMBER = {
     TransactionResult.IDLE: "0",
-    TransactionResult.AGREE: "1",
-    TransactionResult.DISAGREE: "2",
-    TransactionResult.TIMEOUT: "3",
+    TransactionResult.MAJORITY_AGREE: "1",
+    TransactionResult.MAJORITY_DISAGREE: "2",
+    TransactionResult.MAJORITY_TIMEOUT: "3",
     TransactionResult.DETERMINISTIC_VIOLATION: "4",
     TransactionResult.NO_MAJORITY: "5",
-    TransactionResult.MAJORITY_AGREE: "6",
-    TransactionResult.MAJORITY_DISAGREE: "7",
 }
 
 
@@ -117,12 +117,16 @@ class ExecutionResult(str, Enum):
     NOT_VOTED = "NOT_VOTED"
     FINISHED_WITH_RETURN = "FINISHED_WITH_RETURN"
     FINISHED_WITH_ERROR = "FINISHED_WITH_ERROR"
+    TIMEOUT = "TIMEOUT"
+    NONDET_DISAGREE = "NONDET_DISAGREE"
 
 
 EXECUTION_RESULT_NUMBER_TO_NAME = {
     "0": ExecutionResult.NOT_VOTED,
     "1": ExecutionResult.FINISHED_WITH_RETURN,
     "2": ExecutionResult.FINISHED_WITH_ERROR,
+    "3": ExecutionResult.TIMEOUT,
+    "4": ExecutionResult.NONDET_DISAGREE,
 }
 
 

--- a/tests/unit/contracts/test_contract_actions.py
+++ b/tests/unit/contracts/test_contract_actions.py
@@ -2,17 +2,21 @@ from types import SimpleNamespace
 from unittest.mock import Mock
 
 import eth_utils
+import pytest
 from eth_abi import decode as abi_decode
 from web3 import Web3
 
 import genlayer_py.contracts.actions as contract_actions
 from genlayer_py.chains import localnet
+from genlayer_py.chains.testnet_asimov import testnet_asimov
+from genlayer_py.exceptions import GenLayerError
 from genlayer_py.transactions.fees import (
     ADD_TRANSACTION_WITH_FEES_ARGUMENT_TYPES,
     ADD_TRANSACTION_WITH_FEES_SELECTOR,
     CALL_KEY_DEPLOY,
     CALL_KEY_UNNAMED,
     CALL_KEY_WILDCARD,
+    DEPLOY_CALL_KEY,
     FEES_DISTRIBUTION_ABI_TYPE,
     MESSAGE_ALLOCATION_ROOT_PARENT_INDEX,
     MessageType,
@@ -21,6 +25,7 @@ from genlayer_py.transactions.fees import (
     create_fees_distribution,
     derive_external_message_call_key,
     derive_internal_message_call_key,
+    deploy_call_key,
     encode_external_message_fee_params,
     encode_internal_message_fee_params,
     extract_studio_fee_policy,
@@ -29,6 +34,7 @@ from genlayer_py.transactions.fees import (
 
 
 DEFAULT_PARENT_MESSAGE_RECEIPT_HEADROOM = 10_000
+LOCAL_EXECUTION_BUDGET_FLOOR_GAS = 306_192
 
 
 ADD_TRANSACTION_ABI_V5 = [
@@ -155,7 +161,9 @@ def test_derive_internal_message_call_key_hashes_exact_32_byte_method_name():
 
 
 def test_derive_message_call_key_constants_for_deploy_and_unnamed():
-    assert CALL_KEY_DEPLOY == "0x" + "00" * 32
+    assert DEPLOY_CALL_KEY == "0x" + "00" * 31 + "01"
+    assert CALL_KEY_DEPLOY == DEPLOY_CALL_KEY
+    assert deploy_call_key() == DEPLOY_CALL_KEY
     assert CALL_KEY_UNNAMED == "0x" + "00" * 32
     assert derive_internal_message_call_key("") == CALL_KEY_UNNAMED
 
@@ -275,6 +283,87 @@ def test_top_up_and_submit_appeal_sends_consensus_call_and_returns_tx_id(monkeyp
     assert captured["encoded_data"].startswith(f"0x{selector}")
 
 
+def test_appeal_transaction_auto_resolves_min_bond(monkeypatch):
+    client = _make_client(ADD_TRANSACTION_ABI_WITH_FEES)
+    client.chain.fee_manager_contract = {"address": "0x4444444444444444444444444444444444444444"}
+    client.chain.rounds_storage_contract = {"address": "0x5555555555555555555555555555555555555555"}
+    captured = {}
+
+    monkeypatch.setattr(
+        contract_actions,
+        "get_min_appeal_bond",
+        Mock(return_value=4_321),
+    )
+    monkeypatch.setattr(
+        contract_actions,
+        "_encode_submit_appeal_data",
+        Mock(return_value="0x1234"),
+    )
+
+    def fake_send_consensus_call(**kwargs):
+        captured.update(kwargs)
+        return "0xevmtx"
+
+    monkeypatch.setattr(
+        contract_actions,
+        "_send_consensus_call",
+        fake_send_consensus_call,
+    )
+
+    result = contract_actions.appeal_transaction(
+        self=client,
+        transaction_id=TX_ID,
+    )
+
+    assert result == TX_ID
+    contract_actions.get_min_appeal_bond.assert_called_once_with(client, TX_ID)
+    assert captured["value"] == 4_321
+    assert captured["operation_name"] == "Appeal"
+
+
+def test_top_up_and_submit_appeal_auto_resolves_min_bond(monkeypatch):
+    client = _make_client(ADD_TRANSACTION_ABI_WITH_FEES)
+    client.chain.fee_manager_contract = {"address": "0x4444444444444444444444444444444444444444"}
+    client.chain.rounds_storage_contract = {"address": "0x5555555555555555555555555555555555555555"}
+    captured = {}
+
+    monkeypatch.setattr(
+        contract_actions,
+        "get_min_appeal_bond",
+        Mock(return_value=9_999),
+    )
+
+    def fake_send_consensus_call(**kwargs):
+        captured.update(kwargs)
+        return "0xevmtx"
+
+    monkeypatch.setattr(
+        contract_actions,
+        "_send_consensus_call",
+        fake_send_consensus_call,
+    )
+
+    result = contract_actions.top_up_and_submit_appeal(
+        self=client,
+        transaction_id=TX_ID,
+        distribution={"appealRounds": 1, "rotations": [0, 1]},
+    )
+
+    assert result == TX_ID
+    assert captured["value"] == 9_999
+
+
+def test_appeal_auto_bond_requires_fee_contracts():
+    client = _make_client(ADD_TRANSACTION_ABI_WITH_FEES)
+    client.chain.fee_manager_contract = None
+
+    with pytest.raises(GenLayerError, match="Cannot auto-resolve appeal bond"):
+        contract_actions.appeal_transaction(
+            self=client,
+            transaction_id=TX_ID,
+        )
+
+
 def test_send_consensus_call_returns_localnet_rpc_hash_without_waiting(monkeypatch):
     wait_for_transaction_receipt = Mock()
     sign_transaction = Mock(
@@ -315,6 +404,14 @@ def test_send_consensus_call_returns_localnet_rpc_hash_without_waiting(monkeypat
     wait_for_transaction_receipt.assert_not_called()
 
 
+def test_revert_selector_formatter_names_fee_errors():
+    error = Exception({"data": "0x632be5a1"})
+
+    assert contract_actions._format_rpc_error(error).endswith(
+        "(FeeValueMustBeNonZero)"
+    )
+
+
 def _make_client(add_transaction_abi):
     chain = SimpleNamespace(
         id=61999,
@@ -330,6 +427,113 @@ def _make_client(add_transaction_abi):
         chain=chain,
         local_account=local_account,
         w3=Web3(),
+    )
+
+
+class _FakeContractFunction:
+    def __init__(self, value):
+        self.value = value
+
+    def call(self):
+        return self.value
+
+
+class _FakeFeeManagerFunctions:
+    def __init__(self, values):
+        self.values = values
+
+    def GENPerTimeUnit(self):
+        return _FakeContractFunction(self.values["gen"])
+
+    def storageUnitPrice(self):
+        return _FakeContractFunction(self.values["storage"])
+
+    def quoteGasPrice(self):
+        return _FakeContractFunction(self.values["quote"])
+
+    def messageFeeParamsBudgetFloor(self):
+        return _FakeContractFunction(self.values["floor"])
+
+
+class _FakeEth:
+    def __init__(self, values, gas_price):
+        self.values = values
+        self._gas_price = gas_price
+        self.gas_price_accesses = 0
+
+    def contract(self, address=None, abi=None):
+        return SimpleNamespace(functions=_FakeFeeManagerFunctions(self.values))
+
+    @property
+    def gas_price(self):
+        self.gas_price_accesses += 1
+        if isinstance(self._gas_price, Exception):
+            raise self._gas_price
+        return self._gas_price
+
+
+def _make_fee_policy_client(values, gas_price=0):
+    eth = _FakeEth(values, gas_price)
+    return SimpleNamespace(
+        chain=SimpleNamespace(
+            fee_manager_contract={"address": "0x4444444444444444444444444444444444444444"},
+        ),
+        w3=SimpleNamespace(
+            eth=eth,
+            to_checksum_address=Mock(side_effect=lambda address: address),
+        ),
+    )
+
+
+def test_get_current_fee_policy_uses_effective_receipt_gas_price_and_local_floor():
+    client = _make_fee_policy_client(
+        {"gen": 0, "storage": 0, "quote": 1, "floor": 0},
+        gas_price=2,
+    )
+
+    policy = contract_actions.get_current_fee_policy(client)
+
+    assert policy["enabled"] is True
+    assert policy["receiptGasPrice"] == 2
+    assert policy["executionBudgetFloor"] == 2 * LOCAL_EXECUTION_BUDGET_FLOOR_GAS
+    assert client.w3.eth.gas_price_accesses == 1
+
+
+def test_get_current_fee_policy_refuses_enabled_zero_receipt_price():
+    client = _make_fee_policy_client(
+        {"gen": 1, "storage": 0, "quote": 0, "floor": 0},
+        gas_price=0,
+    )
+
+    with pytest.raises(
+        GenLayerError,
+        match="receipt gas price quoted as zero; refusing to build a zero price cap",
+    ):
+        contract_actions.get_current_fee_policy(client)
+
+
+def test_get_current_fee_policy_does_not_read_network_gas_price_when_disabled():
+    client = _make_fee_policy_client(
+        {"gen": 0, "storage": 0, "quote": 0, "floor": 0},
+        gas_price=AssertionError("eth_gasPrice should not be called"),
+    )
+
+    policy = contract_actions.get_current_fee_policy(client)
+
+    assert policy["enabled"] is False
+    assert policy["receiptGasPrice"] == 0
+    assert client.w3.eth.gas_price_accesses == 0
+
+
+def test_asimov_chain_has_fee_contracts():
+    assert testnet_asimov.fee_manager_contract["address"] == (
+        "0x21737AA4bea8FF12E202BF1BAB23751A95617533"
+    )
+    assert testnet_asimov.rounds_storage_contract["address"] == (
+        "0x1F595c0D549DE0812F127508ea1039636CFA62Cc"
+    )
+    assert testnet_asimov.appeals_contract["address"] == (
+        "0x0F739Dd8f5322b9547c7d19a9621BC2ac8DF4089"
     )
 
 
@@ -687,6 +891,31 @@ def test_estimate_transaction_fees_uses_studio_fee_config():
     assert estimate["feeValue"] == 3_000_011_000
 
 
+def test_extract_studio_fee_policy_fallback_includes_message_reveal_leg():
+    policy = extract_studio_fee_policy(
+        {
+            "enabled": True,
+            "policy": {
+                "genPerTimeUnit": "10",
+                "storageUnitPrice": "20",
+                "receiptGasPrice": "30",
+            },
+        }
+    )
+
+    assert policy["executionBudgetFloor"] == 30 * (
+        210_000
+        + 21_000
+        + 60_000
+        + 7 * 1_000
+        + 100_000
+        + 21_000
+        + 60_000
+        + 32 * 1_000
+        + 32 * 16
+    )
+
+
 def test_estimate_transaction_fees_derives_message_bucket_from_allocations():
     client = SimpleNamespace(
         chain=SimpleNamespace(
@@ -818,6 +1047,52 @@ def test_estimate_transaction_fees_from_simulation_builds_trusted_preset():
     assert estimate["feeValue"] == 613_123
 
 
+def test_simulation_execution_budget_uses_floor_without_default_gas_clobber():
+    client = SimpleNamespace(
+        chain=SimpleNamespace(
+            fee_manager_contract=None,
+            default_number_of_initial_validators=5,
+        ),
+        provider=SimpleNamespace(
+            make_request=Mock(
+                return_value={
+                    "result": {
+                        "enabled": True,
+                        "policy": {
+                            "genPerTimeUnit": "10",
+                            "storageUnitPrice": "0",
+                            "receiptGasPrice": "1",
+                            "messageFeeParamsBudgetFloor": str(
+                                LOCAL_EXECUTION_BUDGET_FLOOR_GAS
+                            ),
+                        },
+                    }
+                }
+            )
+        ),
+    )
+
+    estimate = contract_actions.estimate_transaction_fees_from_simulation(
+        self=client,
+        options={
+            "simulation": {
+                "feeAccounting": {
+                    "execution_fee_consumed": "10",
+                    "execution_fee_report": {"totalEstimatedFee": "0"},
+                }
+            },
+            "executionHeadroomBps": 10_000,
+        },
+    )
+
+    assert estimate["observed"]["recommendedExecutionBudgetPerRound"] == (
+        LOCAL_EXECUTION_BUDGET_FLOOR_GAS
+    )
+    assert estimate["distribution"]["executionBudgetPerRound"] == (
+        LOCAL_EXECUTION_BUDGET_FLOOR_GAS
+    )
+
+
 def test_estimate_transaction_fees_for_write_uses_studio_estimate_rpc():
     fee_params = encode_internal_message_fee_params(
         {
@@ -928,7 +1203,7 @@ def test_estimate_transaction_fees_for_write_uses_studio_estimate_rpc():
         request_params["fees"]["messageAllocations"][0]["callKey"]
         == "0x" + "00" * 32
     )
-    assert estimate["observed"]["recommendedExecutionBudgetPerRound"] == 100_000_000
+    assert estimate["observed"]["recommendedExecutionBudgetPerRound"] == 602_117
     assert estimate["observed"]["messageFeeBudget"] == 110
     assert estimate["observed"]["messageFeeConsumed"] == 50
     assert estimate["simulation"]["feeAccounting"]["message_fee_budget"] == "110"

--- a/tests/unit/transactions/test_wait_for_transaction_receipt.py
+++ b/tests/unit/transactions/test_wait_for_transaction_receipt.py
@@ -3,8 +3,15 @@ from unittest.mock import patch
 from genlayer_py.transactions.actions import (
     wait_for_transaction_receipt,
     _simplify_transaction_receipt,
+    is_successful,
 )
-from genlayer_py.types import TransactionStatus, DECIDED_STATES, is_decided_state
+from genlayer_py.types import (
+    ExecutionResult,
+    TransactionStatus,
+    DECIDED_STATES,
+    TRANSACTION_STATUS_NUMBER_TO_NAME,
+    is_decided_state,
+)
 from genlayer_py.exceptions import GenLayerError
 
 
@@ -162,6 +169,43 @@ class TestWaitForTransactionReceipt:
             
             assert result == mock_transaction
 
+    def test_wait_until_decided_resolves_on_undetermined(self, mock_client):
+        mock_transaction = {
+            "hash": "0x4b8037744adab7ea8335b4f839979d20031d83a8ccdf706e0ae61312930335f6",
+            "status": "6",
+            "status_name": "UNDETERMINED",
+        }
+        mock_client.get_transaction.return_value = mock_transaction
+
+        result = wait_for_transaction_receipt(
+            self=mock_client,
+            transaction_hash="0x4b8037744adab7ea8335b4f839979d20031d83a8ccdf706e0ae61312930335f6",
+            wait_until="decided",
+            full_transaction=True,
+        )
+
+        assert result == mock_transaction
+
+    def test_status_14_does_not_crash_wait_loop(self, mock_client):
+        mock_transaction = {
+            "hash": "0x4b8037744adab7ea8335b4f839979d20031d83a8ccdf706e0ae61312930335f6",
+            "status": "14",
+            "status_name": "LEADER_REVEALING",
+        }
+        mock_client.get_transaction.return_value = mock_transaction
+
+        with pytest.raises(GenLayerError, match="LEADER_REVEALING"):
+            wait_for_transaction_receipt(
+                self=mock_client,
+                transaction_hash="0x4b8037744adab7ea8335b4f839979d20031d83a8ccdf706e0ae61312930335f6",
+                wait_until="finalized",
+                retries=1,
+                interval=1,
+                full_transaction=True,
+            )
+
+        assert TRANSACTION_STATUS_NUMBER_TO_NAME["14"] == TransactionStatus.LEADER_REVEALING
+
     def test_wait_for_specific_status_not_affected(self, mock_client):
         """Test that waiting for specific non-ACCEPTED statuses is not affected by decided states logic"""
         mock_transaction = {
@@ -225,6 +269,34 @@ class TestDecidedStatesUtility:
         for status in invalid_statuses:
             if status is not None:
                 assert is_decided_state(status) == False, f"Invalid status {status} should not be decided"
+
+
+class TestIsSuccessful:
+    def test_truth_table(self):
+        assert is_successful(
+            {
+                "status": "5",
+                "tx_execution_result": "1",
+            }
+        )
+        assert not is_successful(
+            {
+                "status": "6",
+                "tx_execution_result": "1",
+            }
+        )
+        assert not is_successful(
+            {
+                "status": TransactionStatus.ACCEPTED,
+                "tx_execution_result": "2",
+            }
+        )
+        assert is_successful(
+            {
+                "status_name": TransactionStatus.FINALIZED,
+                "tx_execution_result_name": ExecutionResult.FINISHED_WITH_RETURN,
+            }
+        )
 
 
 class TestSimplifyTransactionReceipt:


### PR DESCRIPTION
Mirror of genlayerlabs/genlayer-js#187 (same designer rulings, 2026-06-09 fee walkthrough), plus py-specific parity fixes.

## Mirrored
- Effective receipt gas price `max(quoteGasPrice(), eth_gasPrice)`; zero price on an enabled policy raises (consensus rejects zero caps with `FeeValueMustBeNonZero` since CON-547); effective budget floor `max(on-chain view, price × 306,192 gas)`.
- Simulation-derived budgets no longer clobbered by the provisional 100M default.
- `wait_until='decided'|'finalized'` (legacy `status` maps with one-time DeprecationWarning); new `is_successful(tx)`.
- Enum completeness: **status 14 LEADER_REVEALING — fixes a KeyError crash mid-poll** (the map lookup was unguarded), VoteType 3/4, v0.6 ResultType remap; `DEPLOY_CALL_KEY = bytes32(1)`; fee revert selector naming in send errors.

## py-specific
- **asimov chain config gains the fee contracts** (FeeManager/RoundsStorage/Appeals — addresses verified against the js chain config); fee APIs were unusable on asimov from py.
- Studio floor-fallback formula unified with js (message-reveal leg was missing → divergent quotes).
- `appeal_transaction`/`top_up_and_submit_appeal` auto-resolve the minimum bond when `value` is omitted — previously defaulted to 0, a guaranteed on-chain revert; `top_up_fees` now requires `value`.

Verified: 90/90 non-network unit tests (17 testnet-marked tests require live RPC DNS, deselected as usual).