### PR TITLE
fix(fees)!: move wildcard callKey sentinel to keccak256(empty), deploy key = bytes32(0)

### DIFF
--- a/genlayer_py/transactions/fees.py
+++ b/genlayer_py/transactions/fees.py
@@ -154,9 +154,15 @@ class NormalizedTransactionFees(TypedDict):
 
 
 MESSAGE_ALLOCATION_ROOT_PARENT_INDEX = (1 << 256) - 1
-CALL_KEY_WILDCARD = b"\x00" * 32
+# Wildcard sentinel = keccak256 of empty bytes, untagged. Reserved: it can never be a
+# derived key — short names (<32B) are left-aligned with a zero tail byte, long names
+# get the low bit forced to 1, and this hash has neither.
+CALL_KEY_WILDCARD = bytes.fromhex(
+    "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+)
+# Empty method name derives bytes32(0); GenVM emits it for deploy and emit_transfer.
 CALL_KEY_UNNAMED = HexStr("0x" + ("0" * 64))
-DEPLOY_CALL_KEY = HexStr("0x" + ("0" * 62) + "01")
+DEPLOY_CALL_KEY = CALL_KEY_UNNAMED
 CALL_KEY_DEPLOY = DEPLOY_CALL_KEY
 
 FEES_DISTRIBUTION_ABI_TYPE = (

--- a/tests/unit/contracts/test_contract_actions.py
+++ b/tests/unit/contracts/test_contract_actions.py
@@ -161,7 +161,13 @@ def test_derive_internal_message_call_key_hashes_exact_32_byte_method_name():
 
 
 def test_derive_message_call_key_constants_for_deploy_and_unnamed():
-    assert DEPLOY_CALL_KEY == "0x" + "00" * 31 + "01"
+    # Wildcard is the untagged hash of empty bytes — outside the derived-key space.
+    assert CALL_KEY_WILDCARD == eth_utils.keccak(b"")
+    assert CALL_KEY_WILDCARD == bytes.fromhex(
+        "c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+    )
+    # Empty name derives bytes32(0): the natural key for deploy and emit_transfer.
+    assert DEPLOY_CALL_KEY == "0x" + "00" * 32
     assert CALL_KEY_DEPLOY == DEPLOY_CALL_KEY
     assert deploy_call_key() == DEPLOY_CALL_KEY
     assert CALL_KEY_UNNAMED == "0x" + "00" * 32
@@ -594,7 +600,7 @@ def test_simulate_write_contract_passes_fee_policy_and_value_to_sim_call():
     assert request_params["fees"]["messageAllocations"][0]["budget"] == 5
     assert (
         request_params["fees"]["messageAllocations"][0]["callKey"]
-        == "0x" + "00" * 32
+        == "0x" + CALL_KEY_WILDCARD.hex()
     )
 
 
@@ -1201,7 +1207,7 @@ def test_estimate_transaction_fees_for_write_uses_studio_estimate_rpc():
     assert request_params["fees"]["messageAllocations"][0]["budget"] == 110
     assert (
         request_params["fees"]["messageAllocations"][0]["callKey"]
-        == "0x" + "00" * 32
+        == "0x" + CALL_KEY_WILDCARD.hex()
     )
     assert estimate["observed"]["recommendedExecutionBudgetPerRound"] == 602_117
     assert estimate["observed"]["messageFeeBudget"] == 110


### PR DESCRIPTION
## Context

Closes out the deploy/wildcard callKey collision (fee-audit Q2b/Q2c, revised per GenVM team input).

`bytes32(0)` is GenVM's **natural** empty-method-name key — emitted for deploy and `emit_transfer`. The wildcard sentinel also being `bytes32(0)` made deploy-specific Mode-2 allocations impossible. Instead of asking GenVM to emit a new deploy sentinel (`bytes32(1)`, now withdrawn), the **wildcard** moves off zero:

- `CALL_KEY_WILDCARD` = untagged `keccak256(b"")` = `0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`
  Provably outside the derived-key space: short names (<32B) are left-aligned with a zero tail byte, long names get the low bit forced to 1 — this hash has neither.
- `DEPLOY_CALL_KEY` / `CALL_KEY_DEPLOY` = `CALL_KEY_UNNAMED` = `bytes32(0)` — matches what GenVM actually emits. The `bytes32(1)` value from #90 was never live anywhere.
- Default callKey for allocations that omit it stays "wildcard" — only the constant's value changes.

## Coordination

Must land together in v0.6 with:
- consensus: `CALL_KEY_WILDCARD` constant in `MessageFeeAllocations.sol`
- node: Mode-2 tree decode (`convertConsensusAllocationNode`) — map new hash → GenVM wildcard, pass `bytes32(0)` through as a concrete key
- genlayer-js: mirror PR genlayerlabs/genlayer-js#190

No migration concern: no allocation trees exist on any deployed network.

## Testing

`uv run pytest tests/unit` — 107 passed.


Depends-On: genlayerlabs/genlayer-js#190
