### PR TITLE
fix: bump package version to v0.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "genlayer-py"
-version = "0.18.0"
+version = "0.19.0"
 description = "GenLayer Python SDK"
 authors = [
     { name = "GenLayer" }


### PR DESCRIPTION
## Summary
- bump package metadata from 0.18.0 to 0.19.0 on the v0.19 train
- unblocks downstream packages that depend on genlayer-py >=0.19.0

## Validation
- consumed by testing-suite focused validation via local editable dependency