### PR TITLE
fix: use named parameter check instead of fragile >= 6 count for ABI version detection

### DIFF
--- a/genlayer_py/contracts/actions.py
+++ b/genlayer_py/contracts/actions.py
@@ -601,7 +601,8 @@ def _get_add_transaction_abi_version(abi: Optional[list]) -> str:
         inputs = entry.get("inputs", [])
         if len(inputs) == 1 and inputs[0].get("type") == "tuple":
             return "fees"
-        if len(inputs) >= 6:
+        input_names = [inp.get("name", "") for inp in inputs]
+        if "valid_until" in input_names:
             return "v6"
         return "v5"
 


### PR DESCRIPTION
## Summary

Replaces a fragile argument-count check with a named-parameter check for detecting the `addTransaction` ABI version.

## Problem

```python
if len(inputs) >= 6:
    return "v6"
```

This check works accidentally today (Bradbury has 6 args, Asimov has 5), but will silently break if a future protocol upgrade adds a 7th argument — causing an extra positional argument to be supplied and corrupting transaction encoding.

Fixes #310

## Fix

```python
input_names = [inp.get("name", "") for inp in inputs]
if "valid_until" in input_names:
    return "v6"
```

This correctly detects the v6 ABI by checking for the presence of the `valid_until` named parameter, regardless of how many other arguments are added in future upgrades.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version detection for transaction submission so the app now more reliably handles different request formats.
  * Better distinguishes between supported transaction input structures, reducing the chance of version-related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->