### PR TITLE
fix: resolve v0.19-dev bug-hunt findings

### DIFF
--- a/genlayer_py/abi/calldata/decoder.py
+++ b/genlayer_py/abi/calldata/decoder.py
@@ -8,11 +8,24 @@ from genlayer_py.exceptions import GenLayerError
 def decode(mem0: Buffer) -> CalldataEncodable:
     mem: memoryview = memoryview(mem0)
 
+    def take(length: int, label: str) -> memoryview:
+        nonlocal mem
+        if len(mem) < length:
+            raise GenLayerError(
+                f"truncated calldata while reading {label}: "
+                f"expected {length} bytes, found {len(mem)}"
+            )
+        result = mem[:length]
+        mem = mem[length:]
+        return result
+
     def read_uleb128() -> int:
         nonlocal mem
         ret = 0
         off = 0
         while True:
+            if len(mem) == 0:
+                raise GenLayerError("unexpected end of calldata while reading ULEB128")
             m = mem[0]
             ret = ret | ((m & 0x7F) << off)
             off += 7
@@ -33,9 +46,7 @@ def decode(mem0: Buffer) -> CalldataEncodable:
             if code == consts.SPECIAL_TRUE:
                 return True
             if code == consts.SPECIAL_ADDR:
-                ret_addr = mem[: CalldataAddress.SIZE]
-                mem = mem[CalldataAddress.SIZE :]
-                return CalldataAddress(ret_addr)
+                return CalldataAddress(take(CalldataAddress.SIZE, "address"))
             raise GenLayerError(f"Unknown special {bin(code)} {hex(code)}")
         code = code >> 3
         if typ == consts.TYPE_PINT:
@@ -43,12 +54,9 @@ def decode(mem0: Buffer) -> CalldataEncodable:
         elif typ == consts.TYPE_NINT:
             return -code - 1
         elif typ == consts.TYPE_BYTES:
-            ret_bytes = mem[:code]
-            mem = mem[code:]
-            return ret_bytes
+            return take(code, "bytes")
         elif typ == consts.TYPE_STR:
-            ret_str = mem[:code]
-            mem = mem[code:]
+            ret_str = take(code, "string")
             return str(ret_str, encoding="utf-8")
         elif typ == consts.TYPE_ARR:
             ret_arr = []
@@ -60,8 +68,7 @@ def decode(mem0: Buffer) -> CalldataEncodable:
             prev = None
             for _i in range(code):
                 le = read_uleb128()
-                key = str(mem[:le], encoding="utf-8")
-                mem = mem[le:]
+                key = str(take(le, "map key"), encoding="utf-8")
                 if prev is not None:
                     assert prev < key
                 prev = key

--- a/genlayer_py/client/client.py
+++ b/genlayer_py/client/client.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import Optional
 from genlayer_py.types import GenLayerChain
 from genlayer_py.chains import localnet
@@ -10,7 +11,7 @@ def create_client(
     endpoint: Optional[str] = None,
     account: Optional[LocalAccount] = None,
 ) -> GenLayerClient:
-    chain_config = chain or localnet
+    chain_config = deepcopy(chain or localnet)
     if endpoint is not None:
         chain_config.rpc_urls["default"]["http"] = [endpoint]
     client = GenLayerClient(chain_config, account)

--- a/genlayer_py/contracts/actions.py
+++ b/genlayer_py/contracts/actions.py
@@ -93,7 +93,8 @@ def read_contract(
 ) -> CalldataEncodable:
     if account is None and self.local_account is None:
         raise GenLayerError("No account provided and no account is connected")
-    sender_address = self.local_account.address
+    sender = account if account is not None else self.local_account
+    sender_address = sender.address
     data = [
         calldata.encode(
             make_calldata_object(method=function_name, args=args, kwargs=kwargs)

--- a/genlayer_py/transactions/actions.py
+++ b/genlayer_py/transactions/actions.py
@@ -150,6 +150,19 @@ def is_successful(transaction: GenLayerTransaction) -> bool:
             transaction.get("tx_execution_result"),
         )
     )
+
+    if execution_result_name is None:
+        consensus_data = transaction.get("consensus_data")
+        if isinstance(consensus_data, dict):
+            leader_receipt = consensus_data.get("leader_receipt")
+            if isinstance(leader_receipt, list):
+                leader_receipt = leader_receipt[0] if leader_receipt else None
+            if (
+                isinstance(leader_receipt, dict)
+                and leader_receipt.get("execution_result") == "SUCCESS"
+            ):
+                execution_result_name = ExecutionResult.FINISHED_WITH_RETURN
+
     return (
         status_name in (TransactionStatus.ACCEPTED, TransactionStatus.FINALIZED)
         and execution_result_name == ExecutionResult.FINISHED_WITH_RETURN

--- a/tests/unit/test_bug_hunt_v019.py
+++ b/tests/unit/test_bug_hunt_v019.py
@@ -1,0 +1,76 @@
+"""Regression tests for high-confidence defects found on v0.19-dev.
+
+These tests are intentionally red until the corresponding production defects
+are fixed.
+"""
+
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from genlayer_py.abi import calldata
+from genlayer_py.chains import localnet
+from genlayer_py.client.client import GenLayerClient, create_client
+from genlayer_py.contracts.actions import read_contract
+from genlayer_py.exceptions import GenLayerError
+from genlayer_py.transactions.actions import is_successful
+
+
+def test_create_client_endpoint_does_not_mutate_caller_chain_config():
+    chain = deepcopy(localnet)
+    original_endpoints = list(chain.rpc_urls["default"]["http"])
+
+    with patch.object(GenLayerClient, "initialize_consensus_smart_contract"):
+        client = create_client(chain=chain, endpoint="http://override.invalid:8545")
+
+    assert client.chain.rpc_urls["default"]["http"] == [
+        "http://override.invalid:8545"
+    ]
+    assert chain.rpc_urls["default"]["http"] == original_endpoints
+
+
+def test_read_contract_uses_explicit_account_when_client_has_no_default():
+    account = SimpleNamespace(
+        address="0x1111111111111111111111111111111111111111"
+    )
+    provider = Mock()
+    provider.make_request.return_value = {"result": ""}
+    client = SimpleNamespace(local_account=None, provider=provider)
+
+    assert (
+        read_contract(
+            self=client,
+            address="0x2222222222222222222222222222222222222222",
+            function_name="balance",
+            account=account,
+            raw_return=True,
+        )
+        == "0x"
+    )
+    request = provider.make_request.call_args.kwargs["params"][0]
+    assert request["from"] == account.address
+
+
+def test_calldata_decoder_rejects_truncated_length_prefixed_bytes():
+    declares_two_bytes_but_contains_one = bytes([(2 << 3) | 3, 0xAA])
+
+    with pytest.raises(GenLayerError, match="truncated|unexpected end|invalid"):
+        calldata.decode(declares_two_bytes_but_contains_one)
+
+
+def test_is_successful_recognizes_localnet_consensus_receipt():
+    transaction = {
+        "status_name": "FINALIZED",
+        "consensus_data": {
+            "leader_receipt": [
+                {
+                    "mode": "leader",
+                    "execution_result": "SUCCESS",
+                }
+            ]
+        },
+    }
+
+    assert is_successful(transaction)


### PR DESCRIPTION
## What

Fixes four confirmed `v0.19-dev` SDK defects and retains their regression coverage:

- copy chain configuration before applying a client endpoint override
- honor an explicit account in `read_contract`
- reject truncated calldata at every length-prefixed read
- recognize successful localnet/Studio leader receipts when no explicit execution result exists

Explicit transaction execution errors remain authoritative.

## Validation

- Bug-hunt regressions: 4 passed
- Full unit suite: 136 passed
- `git diff --check`