### PR TITLE
fix: include pending transactions in default nonce lookup

### DIFF
--- a/genlayer_py/accounts/actions.py
+++ b/genlayer_py/accounts/actions.py
@@ -38,4 +38,9 @@ def get_current_nonce(
     if address is None and self.account is None:
         raise GenLayerError("No address provided and no account is connected")
     address_to_use = address or self.account.address
-    return self.get_transaction_count(address_to_use, block_identifier)
+    # Include locally pending transactions by default so consecutive
+    # submissions do not reuse the same nonce before the first is mined.
+    resolved_block_identifier = (
+        "pending" if block_identifier is None else block_identifier
+    )
+    return self.get_transaction_count(address_to_use, resolved_block_identifier)

--- a/tests/unit/account/test_accounts.py
+++ b/tests/unit/account/test_accounts.py
@@ -1,7 +1,10 @@
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 from genlayer_py.accounts.account import generate_private_key, create_account
+from genlayer_py.accounts.actions import get_current_nonce
 
 
 def test_generate_private_key():
@@ -54,3 +57,25 @@ def test_create_account_with_none_private_key():
     assert (
         account1.address != account2.address
     )  # Different addresses since different random keys
+
+
+def test_get_current_nonce_includes_pending_transactions_by_default():
+    address = "0x0000000000000000000000000000000000000001"
+    client = SimpleNamespace(
+        account=SimpleNamespace(address=address),
+        get_transaction_count=Mock(return_value=7),
+    )
+
+    assert get_current_nonce(client) == 7
+    client.get_transaction_count.assert_called_once_with(address, "pending")
+
+
+def test_get_current_nonce_preserves_explicit_block_identifier():
+    address = "0x0000000000000000000000000000000000000001"
+    client = SimpleNamespace(
+        account=None,
+        get_transaction_count=Mock(return_value=3),
+    )
+
+    assert get_current_nonce(client, address, "latest") == 3
+    client.get_transaction_count.assert_called_once_with(address, "latest")


### PR DESCRIPTION
## Summary
- default `get_current_nonce` to the pending block tag
- preserve explicitly requested block identifiers
- add regression coverage for both paths

## Verification
- `pytest tests/unit --ignore=tests/unit/smoke` (113 passed)