### PR TITLE
fix: use uuid4 for JSON-RPC request id to prevent response correlation

### DIFF
--- a/genlayer_py/provider/provider.py
+++ b/genlayer_py/provider/provider.py
@@ -4,7 +4,7 @@ from typing import Any, Union, List
 from requests import HTTPError
 import requests
 from genlayer_py.exceptions import GenLayerError
-import time
+import uuid
 
 
 class GenLayerProvider(BaseProvider):
@@ -23,7 +23,7 @@ class GenLayerProvider(BaseProvider):
     ) -> RPCResponse:
         payload = {
             "jsonrpc": "2.0",
-            "id": int(time.time() * 1000),
+            "id": str(uuid.uuid4()),
             "method": method,
             "params": params,
         }


### PR DESCRIPTION
## Summary

The JSON-RPC `id` field in `GenLayerProvider.make_request` uses `int(time.time() * 1000)`, a millisecond-resolution timestamp. Two requests sent within the same millisecond (common during `sendTransaction` + `wait_for_receipt`, or any concurrent calls) get the **same `id`**, violating the JSON-RPC spec requirement that `id` must uniquely correlate requests with responses.

## The bug

```python
# Before (provider.py line 19):
"id": int(time.time() * 1000),   # millisecond timestamp — collides frequently
```

When two responses arrive with the same `id`, a `requests.post` call that gets the wrong response will **silently process data intended for a different request**:
- Return a receipt for a different transaction (accepting a revert as success)
- Parse the wrong `txId` from events

## Fix

```python
# After:
"id": str(uuid.uuid4()),   # globally unique, collision-free
```

## Checklist
- [x] Minimal change matching surrounding code style
- [x] No new dependencies (uuid is stdlib)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON-RPC request ID uniqueness and reliability by switching to UUID-based identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->