### PR TITLE
fix: reject unsupported addTransaction ABI arity

### DIFF
--- a/genlayer_py/contracts/actions.py
+++ b/genlayer_py/contracts/actions.py
@@ -909,8 +909,14 @@ def _encode_add_transaction_data(
         consensus_max_rotations,
         self.w3.to_bytes(hexstr=data),
     ]
-    if len(contract_fn.argument_types) >= 6:
+    argument_count = len(contract_fn.argument_types)
+    if argument_count == 6:
         add_transaction_args.append(normalized_valid_until)
+    elif argument_count != 5:
+        raise ValueError(
+            "Unsupported addTransaction ABI: expected 5 or 6 arguments, "
+            f"got {argument_count}"
+        )
 
     params = abi_encode(
         contract_fn.argument_types,

--- a/genlayer_py/contracts/actions.py
+++ b/genlayer_py/contracts/actions.py
@@ -884,6 +884,13 @@ def _encode_add_transaction_data(
     use_fee_aware_transaction = (
         transaction_fees["requires_fee_aware_transaction"] or abi_version == "fees"
     )
+    argument_count = len(contract_fn.argument_types)
+    if abi_version != "fees" and argument_count not in (5, 6):
+        raise ValueError(
+            "Unsupported addTransaction ABI: expected 5 or 6 arguments, "
+            f"got {argument_count}"
+        )
+
     normalized_valid_until = to_uint(
         valid_until,
         "valid_until",
@@ -909,7 +916,6 @@ def _encode_add_transaction_data(
         consensus_max_rotations,
         self.w3.to_bytes(hexstr=data),
     ]
-    argument_count = len(contract_fn.argument_types)
     if argument_count == 6:
         add_transaction_args.append(normalized_valid_until)
     elif argument_count != 5:

--- a/tests/unit/contracts/test_contract_actions.py
+++ b/tests/unit/contracts/test_contract_actions.py
@@ -662,6 +662,20 @@ def test_encode_add_transaction_rejects_unknown_argument_count():
         )
 
 
+def test_encode_add_transaction_rejects_v7_abi_when_fee_aware_transaction_is_requested():
+    client = _make_client(ADD_TRANSACTION_ABI_V7)
+
+    with pytest.raises(ValueError, match="expected 5 or 6 arguments, got 7"):
+        contract_actions._encode_add_transaction_data(
+            self=client,
+            sender_account=client.local_account,
+            recipient=RECIPIENT,
+            consensus_max_rotations=3,
+            data="0x",
+            transaction_fees={"requires_fee_aware_transaction": True},
+        )
+
+
 def test_encode_add_transaction_uses_fee_signature_when_abi_has_tuple_input():
     client = _make_client(ADD_TRANSACTION_ABI_WITH_FEES)
 

--- a/tests/unit/contracts/test_contract_actions.py
+++ b/tests/unit/contracts/test_contract_actions.py
@@ -70,6 +70,23 @@ ADD_TRANSACTION_ABI_V6 = [
     }
 ]
 
+ADD_TRANSACTION_ABI_V7 = [
+    {
+        "type": "function",
+        "name": "addTransaction",
+        "stateMutability": "nonpayable",
+        "inputs": [
+            {"name": "_sender", "type": "address"},
+            {"name": "_recipient", "type": "address"},
+            {"name": "_numOfInitialValidators", "type": "uint256"},
+            {"name": "_maxRotations", "type": "uint256"},
+            {"name": "_calldata", "type": "bytes"},
+            {"name": "_validUntil", "type": "uint256"},
+            {"name": "_futureField", "type": "uint256"},
+        ],
+        "outputs": [],
+    }
+]
 ADD_TRANSACTION_ABI_WITH_FEES = [
     {
         "type": "function",
@@ -630,6 +647,19 @@ def test_encode_add_transaction_uses_v6_signature_when_abi_has_6_inputs():
         text="addTransaction(address,address,uint256,uint256,bytes,uint256)"
     )[:4].hex()
     assert encoded.startswith(f"0x{selector}")
+
+
+def test_encode_add_transaction_rejects_unknown_argument_count():
+    client = _make_client(ADD_TRANSACTION_ABI_V7)
+
+    with pytest.raises(ValueError, match="expected 5 or 6 arguments, got 7"):
+        contract_actions._encode_add_transaction_data(
+            self=client,
+            sender_account=client.local_account,
+            recipient=RECIPIENT,
+            consensus_max_rotations=3,
+            data="0x",
+        )
 
 
 def test_encode_add_transaction_uses_fee_signature_when_abi_has_tuple_input():


### PR DESCRIPTION
### Summary

Closes genlayerlabs/genlayer-cli#310.

The dynamic `addTransaction` encoder now accepts only the known five- and six-argument non-fee-aware ABIs. It raises a descriptive error for a future unsupported argument count instead of silently selecting the six-argument encoding and failing later with an opaque ABI mismatch.

### How did you test your changes?

- `python3 -m compileall -q genlayer_py tests`
- - `git diff --check`
- - Added a regression test for a seven-argument ABI.
- - Pytest was unavailable in the sandbox.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation when preparing add-transaction requests.
  - Unsupported transaction formats are now rejected with a clear error instead of being processed incorrectly.
  - Existing supported five- and six-argument transaction formats continue to work as expected.

- **Tests**
  - Added coverage for invalid seven-argument transaction formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->