### PR TITLE
feat: expose gas overrides for intelligent contract transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,23 @@ receipt = client.wait_for_transaction_receipt(
 )
 ```
 
+`write_contract` and `deploy_contract` accept the same top-level `gas` override
+used for an EVM transaction. It controls only the outer EVM call to
+`ConsensusMain.addTransaction`; GenLayer consensus and execution budgets remain
+under `fees`.
+
+```python
+tx_hash = client.deploy_contract(
+    account=account,
+    code=contract_code,
+    gas=1_000_000,
+)
+```
+
+When `gas` is omitted, the SDK estimates the outer EVM gas and applies safety
+headroom. If estimation fails, the SDK does not broadcast with a guessed limit;
+inspect the revert or retry with an explicit `gas` value.
+
 ### Fee presets for transactions
 
 Apps can build a trusted fee preset once they know the transaction shape, then

--- a/docs/api-references/api.md
+++ b/docs/api-references/api.md
@@ -82,10 +82,11 @@ client.read_contract(address: Union, function_name: str, args: Union = None, kwa
 
 ### write_contract
 
-Executes a state-modifying function on a contract through consensus. Returns the transaction hash.
+Executes a state-modifying function on a contract through consensus. `gas`
+limits the outer EVM transaction and is separate from GenLayer `fees` budgets.
 
 ```python
-client.write_contract(address: Union, function_name: str, account: Union = None, consensus_max_rotations: Union = None, value: int = 0, leader_only: bool = False, args: Union = None, kwargs: Union = None, sim_config: Union = None)
+client.write_contract(address: Union, function_name: str, account: Union = None, consensus_max_rotations: Union = None, value: int = 0, leader_only: bool = False, args: Union = None, kwargs: Union = None, sim_config: Union = None, valid_until: Union = None, fees: Union = None, gas: Union = None)
 ```
 
 | Parameter | Type | Required | Default |
@@ -99,6 +100,9 @@ client.write_contract(address: Union, function_name: str, account: Union = None,
 | args | `Union` | no | None |
 | kwargs | `Union` | no | None |
 | sim_config | `Union` | no | None |
+| valid_until | `Union` | no | None |
+| fees | `Union` | no | None |
+| gas | `Union` | no | None |
 
 ---
 
@@ -124,10 +128,11 @@ client.simulate_write_contract(address: Union, function_name: str, account: Unio
 
 ### deploy_contract
 
-Deploys a new intelligent contract to GenLayer. Returns the transaction hash.
+Deploys a new intelligent contract to GenLayer. `gas` limits the outer EVM
+transaction and is separate from GenLayer `fees` budgets.
 
 ```python
-client.deploy_contract(code: Union, account: Union = None, args: Union = None, kwargs: Union = None, consensus_max_rotations: Union = None, leader_only: bool = False, sim_config: Union = None)
+client.deploy_contract(code: Union, account: Union = None, args: Union = None, kwargs: Union = None, consensus_max_rotations: Union = None, leader_only: bool = False, sim_config: Union = None, valid_until: Union = None, fees: Union = None, gas: Union = None)
 ```
 
 | Parameter | Type | Required | Default |
@@ -139,6 +144,9 @@ client.deploy_contract(code: Union, account: Union = None, args: Union = None, k
 | consensus_max_rotations | `Union` | no | None |
 | leader_only | `bool` | no | False |
 | sim_config | `Union` | no | None |
+| valid_until | `Union` | no | None |
+| fees | `Union` | no | None |
+| gas | `Union` | no | None |
 
 ---
 

--- a/docs/api-references/genlayer-py.md
+++ b/docs/api-references/genlayer-py.md
@@ -82,10 +82,11 @@ client.read_contract(address: Union, function_name: str, args: Union = None, kwa
 
 ### write_contract
 
-Executes a state-modifying function on a contract through consensus. Returns the transaction hash.
+Executes a state-modifying function on a contract through consensus. `gas`
+limits the outer EVM transaction and is separate from GenLayer `fees` budgets.
 
 ```python
-client.write_contract(address: Union, function_name: str, account: Union = None, consensus_max_rotations: Union = None, value: int = 0, leader_only: bool = False, args: Union = None, kwargs: Union = None, sim_config: Union = None)
+client.write_contract(address: Union, function_name: str, account: Union = None, consensus_max_rotations: Union = None, value: int = 0, leader_only: bool = False, args: Union = None, kwargs: Union = None, sim_config: Union = None, valid_until: Union = None, fees: Union = None, gas: Union = None)
 ```
 
 **Parameters:**
@@ -99,6 +100,9 @@ client.write_contract(address: Union, function_name: str, account: Union = None,
 - **args** (`Union`) — optional = None
 - **kwargs** (`Union`) — optional = None
 - **sim_config** (`Union`) — optional = None
+- **valid_until** (`Union`) — optional = None
+- **fees** (`Union`) — optional = None
+- **gas** (`Union`) — optional = None
 
 ---
 
@@ -124,10 +128,11 @@ client.simulate_write_contract(address: Union, function_name: str, account: Unio
 
 ### deploy_contract
 
-Deploys a new intelligent contract to GenLayer. Returns the transaction hash.
+Deploys a new intelligent contract to GenLayer. `gas` limits the outer EVM
+transaction and is separate from GenLayer `fees` budgets.
 
 ```python
-client.deploy_contract(code: Union, account: Union = None, args: Union = None, kwargs: Union = None, consensus_max_rotations: Union = None, leader_only: bool = False, sim_config: Union = None)
+client.deploy_contract(code: Union, account: Union = None, args: Union = None, kwargs: Union = None, consensus_max_rotations: Union = None, leader_only: bool = False, sim_config: Union = None, valid_until: Union = None, fees: Union = None, gas: Union = None)
 ```
 
 **Parameters:**
@@ -139,6 +144,9 @@ client.deploy_contract(code: Union, account: Union = None, args: Union = None, k
 - **consensus_max_rotations** (`Union`) — optional = None
 - **leader_only** (`bool`) — optional = False
 - **sim_config** (`Union`) — optional = None
+- **valid_until** (`Union`) — optional = None
+- **fees** (`Union`) — optional = None
+- **gas** (`Union`) — optional = None
 
 ---
 

--- a/docs/api-references/index.md
+++ b/docs/api-references/index.md
@@ -103,6 +103,23 @@ receipt = client.wait_for_transaction_receipt(
 )
 ```
 
+`write_contract` and `deploy_contract` accept the same top-level `gas` override
+used for an EVM transaction. It controls only the outer EVM call to
+`ConsensusMain.addTransaction`; GenLayer consensus and execution budgets remain
+under `fees`.
+
+```python
+tx_hash = client.deploy_contract(
+    account=account,
+    code=contract_code,
+    gas=1_000_000,
+)
+```
+
+When `gas` is omitted, the SDK estimates the outer EVM gas and applies safety
+headroom. If estimation fails, the SDK does not broadcast with a guessed limit;
+inspect the revert or retry with an explicit `gas` value.
+
 ### Checking execution results
 
 A transaction can be finalized by consensus but still have a failed execution. Always check `tx_execution_result` before reading contract state:

--- a/genlayer_py/client/genlayer_client.py
+++ b/genlayer_py/client/genlayer_client.py
@@ -159,8 +159,14 @@ class GenLayerClient(Eth):
         sim_config: Optional[SimConfig] = None,
         valid_until: Optional[int] = None,
         fees: Optional[TransactionFeeOptions] = None,
+        gas: Optional[int] = None,
     ):
-        """Executes a state-modifying function on a contract through consensus. Returns the transaction hash."""
+        """Executes a state-modifying function on a contract through consensus.
+
+        ``gas`` is the optional limit for the outer EVM transaction and is
+        separate from GenLayer protocol budgets supplied through ``fees``.
+        Returns the transaction hash.
+        """
         return write_contract(
             self=self,
             address=address,
@@ -174,6 +180,7 @@ class GenLayerClient(Eth):
             sim_config=sim_config,
             valid_until=valid_until,
             fees=fees,
+            gas=gas,
         )
 
     def simulate_write_contract(
@@ -215,8 +222,14 @@ class GenLayerClient(Eth):
         sim_config: Optional[SimConfig] = None,
         valid_until: Optional[int] = None,
         fees: Optional[TransactionFeeOptions] = None,
+        gas: Optional[int] = None,
     ):
-        """Deploys a new intelligent contract to GenLayer. Returns the transaction hash."""
+        """Deploys a new intelligent contract to GenLayer.
+
+        ``gas`` is the optional limit for the outer EVM transaction and is
+        separate from GenLayer protocol budgets supplied through ``fees``.
+        Returns the transaction hash.
+        """
         return deploy_contract(
             self=self,
             code=code,
@@ -228,6 +241,7 @@ class GenLayerClient(Eth):
             sim_config=sim_config,
             valid_until=valid_until,
             fees=fees,
+            gas=gas,
         )
 
     def get_contract_schema(

--- a/genlayer_py/contracts/actions.py
+++ b/genlayer_py/contracts/actions.py
@@ -135,6 +135,7 @@ def write_contract(
     sim_config: Optional[SimConfig] = None,
     valid_until: Optional[int] = None,
     fees: Optional[TransactionFeeOptions] = None,
+    gas: Optional[int] = None,
 ):
     if consensus_max_rotations is None:
         consensus_max_rotations = self.chain.default_consensus_max_rotations
@@ -168,6 +169,7 @@ def write_contract(
         sender_account=sender_account,
         value=value + (transaction_fees["fee_value"] or 0),
         sim_config=sim_config,
+        gas=gas,
     )
 
 
@@ -182,6 +184,7 @@ def deploy_contract(
     sim_config: Optional[SimConfig] = None,
     valid_until: Optional[int] = None,
     fees: Optional[TransactionFeeOptions] = None,
+    gas: Optional[int] = None,
 ):
     if consensus_max_rotations is None:
         consensus_max_rotations = self.chain.default_consensus_max_rotations
@@ -215,6 +218,7 @@ def deploy_contract(
         sender_account=sender_account,
         value=transaction_fees["fee_value"] or 0,
         sim_config=sim_config,
+        gas=gas,
     )
 
 
@@ -928,7 +932,13 @@ def _prepare_transaction(
     recipient: Union[Address, ChecksumAddress],
     data: HexStr,
     value: int = 0,
+    gas: Optional[int] = None,
 ) -> Dict[str, Any]:
+
+    if gas is not None and (
+        isinstance(gas, bool) or not isinstance(gas, int) or gas <= 0
+    ):
+        raise GenLayerError("gas must be a positive integer")
 
     nonce = self.get_current_nonce(address=sender)
 
@@ -955,9 +965,29 @@ def _prepare_transaction(
         **fee_data,
         "chainId": self.chain.id,
     }
-    transaction["gas"] = self.provider.make_request(
-        "eth_estimateGas", params=[transaction]
-    )["result"]
+    if gas is not None:
+        transaction["gas"] = gas
+        return transaction
+
+    try:
+        response = self.provider.make_request(
+            "eth_estimateGas", params=[transaction]
+        )
+        if "error" in response:
+            raise GenLayerError(str(response["error"]))
+        estimate = response.get("result")
+        if estimate is None:
+            raise GenLayerError("eth_estimateGas returned no result")
+        estimated_gas = (
+            int(estimate, 0) if isinstance(estimate, str) else int(estimate)
+        )
+        transaction["gas"] = estimated_gas * 2
+    except Exception as exc:
+        raise GenLayerError(
+            "Gas estimation failed for the outer EVM transaction; no transaction was sent. "
+            "Inspect the revert and, if estimation is unreliable, retry with an explicit "
+            f"gas value. Original error: {_format_rpc_error(exc)}"
+        ) from exc
     return transaction
 
 
@@ -1047,6 +1077,7 @@ def _send_transaction(
     sender_account: Optional[LocalAccount] = None,
     value: int = 0,
     sim_config: Optional[SimConfig] = None,
+    gas: Optional[int] = None,
 ):
     if sender_account is None:
         raise GenLayerError(
@@ -1065,6 +1096,7 @@ def _send_transaction(
             recipient=self.chain.consensus_main_contract["address"],
             data=encoded_data,
             value=value,
+            gas=gas,
         )
         signed_transaction = sender_account.sign_transaction(transaction)
         serialized_transaction = self.w3.to_hex(signed_transaction.raw_transaction)

--- a/tests/unit/contracts/test_contract_actions.py
+++ b/tests/unit/contracts/test_contract_actions.py
@@ -418,6 +418,96 @@ def test_revert_selector_formatter_names_fee_errors():
     )
 
 
+def _make_prepare_transaction_client(provider_response):
+    return SimpleNamespace(
+        chain=SimpleNamespace(id=localnet.id),
+        get_current_nonce=Mock(return_value=7),
+        provider=SimpleNamespace(
+            make_request=Mock(return_value=provider_response),
+        ),
+    )
+
+
+def test_prepare_transaction_applies_estimate_headroom():
+    client = _make_prepare_transaction_client({"result": "0x5208"})
+
+    transaction = contract_actions._prepare_transaction(
+        self=client,
+        sender=SENDER,
+        recipient=RECIPIENT,
+        data="0x1234",
+    )
+
+    assert transaction["gas"] == 42_000
+    client.provider.make_request.assert_called_once()
+    assert client.provider.make_request.call_args.args[0] == "eth_estimateGas"
+
+
+def test_prepare_transaction_uses_explicit_gas_without_estimating():
+    client = _make_prepare_transaction_client({"result": "0x5208"})
+
+    transaction = contract_actions._prepare_transaction(
+        self=client,
+        sender=SENDER,
+        recipient=RECIPIENT,
+        data="0x1234",
+        gas=32_000_000,
+    )
+
+    assert transaction["gas"] == 32_000_000
+    client.provider.make_request.assert_not_called()
+
+
+@pytest.mark.parametrize("gas", [0, -1, True, 1.5])
+def test_prepare_transaction_rejects_invalid_explicit_gas(gas):
+    client = _make_prepare_transaction_client({"result": "0x5208"})
+
+    with pytest.raises(GenLayerError, match="gas must be a positive integer"):
+        contract_actions._prepare_transaction(
+            self=client,
+            sender=SENDER,
+            recipient=RECIPIENT,
+            data="0x1234",
+            gas=gas,
+        )
+
+    client.provider.make_request.assert_not_called()
+
+
+def test_send_transaction_stops_before_broadcast_when_estimation_fails():
+    provider = SimpleNamespace(
+        make_request=Mock(
+            return_value={
+                "error": {"message": "execution reverted", "data": "0x305e533c"}
+            }
+        )
+    )
+    client = SimpleNamespace(
+        chain=SimpleNamespace(
+            id=localnet.id,
+            name="localnet",
+            consensus_main_contract={"address": RECIPIENT},
+        ),
+        get_current_nonce=Mock(return_value=7),
+        provider=provider,
+    )
+    account = SimpleNamespace(address=SENDER, sign_transaction=Mock())
+
+    with pytest.raises(
+        GenLayerError,
+        match="no transaction was sent.*BudgetTooLow",
+    ):
+        contract_actions._send_transaction(
+            self=client,
+            encoded_data="0x1234",
+            sender_account=account,
+        )
+
+    account.sign_transaction.assert_not_called()
+    assert provider.make_request.call_count == 1
+    assert provider.make_request.call_args.args[0] == "eth_estimateGas"
+
+
 def _make_client(add_transaction_abi):
     chain = SimpleNamespace(
         id=61999,
@@ -696,10 +786,12 @@ def test_write_contract_separates_user_value_from_fee_deposit(monkeypatch):
                 }
             ],
         },
+        gas=32_000_000,
     )
 
     assert result == "0xdeadbeef"
     assert captured["value"] == 128
+    assert captured["gas"] == 32_000_000
 
     params = abi_decode(
         ADD_TRANSACTION_WITH_FEES_ARGUMENT_TYPES,
@@ -713,6 +805,28 @@ def test_write_contract_separates_user_value_from_fee_deposit(monkeypatch):
     assert params[9][0][4] == CALL_KEY_WILDCARD
     assert params[9][0][5] == 123
     assert params[9][0][6] == b"\x12\x34"
+
+
+def test_deploy_contract_forwards_outer_evm_gas(monkeypatch):
+    client = _make_client(ADD_TRANSACTION_ABI_V5)
+    client.initialize_consensus_smart_contract = Mock()
+    captured = {}
+
+    def fake_send_transaction(**kwargs):
+        captured.update(kwargs)
+        return "0xdeadbeef"
+
+    monkeypatch.setattr(contract_actions, "_send_transaction", fake_send_transaction)
+
+    result = contract_actions.deploy_contract(
+        self=client,
+        code="print('hello')",
+        account=client.local_account,
+        gas=31_000_000,
+    )
+
+    assert result == "0xdeadbeef"
+    assert captured["gas"] == 31_000_000
 
 
 def test_write_contract_defaults_external_message_allocations_to_finalization(monkeypatch):


### PR DESCRIPTION
## Delivery context

No direct cross-repository dependency. This is the Python SDK parity implementation of the same public transaction-level gas convention.

## Problem and outcome

Large intelligent-contract deploy/write calldata can exceed a guessed outer EVM gas limit. The Python SDK previously offered no transaction-level override, so callers could not bypass an unreliable `eth_estimateGas` result.

This PR:

- adds optional top-level `gas` to `write_contract` and `deploy_contract`;
- passes an explicit positive integer unchanged and skips `eth_estimateGas`;
- applies 2× safety headroom when estimation succeeds and no override is supplied;
- stops before signing or broadcast when estimation fails, preserving known revert selectors in the error;
- documents that `gas` controls the outer EVM `ConsensusMain.addTransaction` call and is separate from GenLayer `fees` budgets.

There is no protocol, consensus, or fee-accounting change.

## Implementation and validation

Validation:

- `.venv/bin/pytest tests/unit/contracts/test_contract_actions.py -q` — 45 passed.
- `.venv/bin/pytest tests/unit --ignore=tests/unit/smoke -q` — 124 passed.
- `.venv/bin/python -m compileall -q genlayer_py` — passed.

The excluded `tests/unit/smoke` directory performs live Bradbury/Asimov RPC calls; its sandbox run failed only on blocked DNS/network access. No live transaction was broadcast for this change.

Coverage includes:

- explicit write/deploy gas propagation;
- estimation bypass;
- positive-integer validation;
- 2× estimated-gas headroom;
- no signing or broadcast on estimation failure;
- decoded `BudgetTooLow` error context.

## Decisions, risks, and rollback

- Public spelling is `gas`, matching standard EVM transaction APIs and genlayer-js.
- `gas` is deliberately outside the `fees` object because it belongs to the outer EVM envelope, not GenLayer execution/consensus budgets.
- Default Python behavior now includes the same 2× estimation margin used by genlayer-js. This raises only the limit; normal EVM charging remains based on gas used.
- Reverting this commit restores exact-estimate behavior and removes the override.