### PR TITLE
fix: return bytes when decoding calldata bytes

### DIFF
--- a/genlayer_py/abi/calldata/decoder.py
+++ b/genlayer_py/abi/calldata/decoder.py
@@ -45,7 +45,7 @@ def decode(mem0: Buffer) -> CalldataEncodable:
         elif typ == consts.TYPE_BYTES:
             ret_bytes = mem[:code]
             mem = mem[code:]
-            return ret_bytes
+            return bytes(ret_bytes)
         elif typ == consts.TYPE_STR:
             ret_str = mem[:code]
             mem = mem[code:]

--- a/tests/unit/abi/test_calldata.py
+++ b/tests/unit/abi/test_calldata.py
@@ -1,0 +1,15 @@
+from genlayer_py.abi import calldata
+
+
+def test_decode_bytes_returns_bytes():
+    decoded = calldata.decode(calldata.encode(b"hello"))
+
+    assert isinstance(decoded, bytes)
+    assert decoded == b"hello"
+
+
+def test_decoded_bytes_round_trip_through_to_str():
+    value = b"hello"
+    decoded = calldata.decode(calldata.encode(value))
+
+    assert calldata.to_str(decoded) == calldata.to_str(value)


### PR DESCRIPTION
## Summary
- return `bytes` for decoded `TYPE_BYTES` calldata values
- add regression coverage for the decoded type and `to_str()` handling

## Tests
- `python -m pytest tests\unit\abi\test_calldata.py`
- `python -m pytest tests\unit --disable-warnings -v -m "not testnet"`
- `python -m pytest tests\unit`
- `python -m black --check genlayer_py\abi\calldata\decoder.py tests\unit\abi\test_calldata.py`

Fixes #108