### PR TITLE
fix: align localnet chain id with Studio

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Setup | Install Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
 
+      - name: Check | Verify locked package metadata
+        run: uv lock --check
+
       - name: Setup | Install Dependencies
         run: uv sync --group dev --python ${{ matrix.python-version }}
 

--- a/genlayer_py/chains/localnet.py
+++ b/genlayer_py/chains/localnet.py
@@ -16,7 +16,7 @@ CONSENSUS_DATA_CONTRACT = {
 }
 
 localnet: GenLayerChain = GenLayerChain(
-    id=61999,
+    id=61127,
     name="GenLayer Localnet",
     rpc_urls={
         "default": {

--- a/genlayer_py/chains/utils.py
+++ b/genlayer_py/chains/utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from genlayer_py.types import GenLayerChain
 
 
-STUDIO_CHAIN_IDS = frozenset({61997, 61999})
+STUDIO_CHAIN_IDS = frozenset({61127, 61997, 61999})
 
 
 def is_studio_chain(chain: GenLayerChain) -> bool:

--- a/releaserc.toml
+++ b/releaserc.toml
@@ -1,6 +1,7 @@
 [semantic_release]
 version_toml = ["pyproject.toml:project.version"]
-assets = []
+assets = ["uv.lock"]
+build_command = "uv lock"
 build_command_env = []
 commit_message = "chore(release): {version}"
 commit_parser = "conventional"

--- a/tests/unit/chains/test_chain_presets.py
+++ b/tests/unit/chains/test_chain_presets.py
@@ -1,6 +1,7 @@
 import genlayer_py
 
 from genlayer_py.chains import __all__ as chain_exports
+from genlayer_py.chains.localnet import localnet
 from genlayer_py.chains.studio_devnet import (
     STUDIO_DEVNET_EXPLORER_URL,
     STUDIO_DEVNET_JSON_RPC_URL,
@@ -9,6 +10,13 @@ from genlayer_py.chains.studio_devnet import (
 from genlayer_py.chains.studionet import studionet
 from genlayer_py.chains.testnet_asimov import testnet_asimov
 from genlayer_py.chains.utils import is_studio_chain
+
+
+def test_localnet_uses_the_canonical_local_studio_chain_id():
+    assert localnet.id == 61127
+    assert localnet.rpc_urls == {
+        "default": {"http": ["http://127.0.0.1:4000/api"]}
+    }
 
 
 def test_studio_devnet_is_exported_with_canonical_preview_coordinates():
@@ -41,6 +49,11 @@ def test_stable_studionet_coordinates_do_not_drift_with_preview_preset():
 
 
 def test_studio_chain_classification_includes_preview_but_not_public_testnet():
+    assert is_studio_chain(localnet)
     assert is_studio_chain(studionet)
     assert is_studio_chain(studio_devnet)
     assert not is_studio_chain(testnet_asimov)
+
+
+def test_studio_presets_have_distinct_chain_ids():
+    assert len({localnet.id, studio_devnet.id, studionet.id}) == 3

--- a/tests/unit/contracts/test_contract_actions.py
+++ b/tests/unit/contracts/test_contract_actions.py
@@ -751,9 +751,17 @@ def test_encode_submit_appeal_still_requires_a_decision_id_on_the_train_shape():
         contract_actions._encode_submit_appeal_data(self=client, transaction_id=TX_ID)
 
 
-def test_send_consensus_call_returns_localnet_envelope_hash_after_receipt(monkeypatch):
+def test_send_consensus_call_signs_for_canonical_local_studio_chain():
     wait_for_transaction_receipt = Mock(return_value=SimpleNamespace(status=1))
     sign_transaction = Mock(return_value=SimpleNamespace(raw_transaction=b"\x12\x34"))
+
+    def make_request(method, params):
+        if method == "eth_estimateGas":
+            return {"result": "0x5208"}
+        if method == "eth_sendRawTransaction":
+            return {"result": TX_ID}
+        raise AssertionError(f"unexpected method {method}")
+
     client = SimpleNamespace(
         chain=SimpleNamespace(
             id=localnet.id,
@@ -761,7 +769,8 @@ def test_send_consensus_call_returns_localnet_envelope_hash_after_receipt(monkey
                 "address": "0x3333333333333333333333333333333333333333",
             },
         ),
-        provider=SimpleNamespace(make_request=Mock(return_value={"result": TX_ID})),
+        get_current_nonce=Mock(return_value=7),
+        provider=SimpleNamespace(make_request=Mock(side_effect=make_request)),
         w3=SimpleNamespace(
             to_hex=Mock(return_value="0xsigned"),
             eth=SimpleNamespace(
@@ -770,12 +779,6 @@ def test_send_consensus_call_returns_localnet_envelope_hash_after_receipt(monkey
         ),
     )
     account = SimpleNamespace(address=SENDER, sign_transaction=sign_transaction)
-
-    monkeypatch.setattr(
-        contract_actions,
-        "_prepare_transaction",
-        Mock(return_value={"from": SENDER}),
-    )
 
     result = contract_actions._send_consensus_call(
         self=client,
@@ -786,6 +789,17 @@ def test_send_consensus_call_returns_localnet_envelope_hash_after_receipt(monkey
     )
 
     assert result == TX_ID
+    transaction = sign_transaction.call_args.args[0]
+    assert transaction == {
+        "from": SENDER,
+        "nonce": "0x7",
+        "data": "0x1234",
+        "to": "0x3333333333333333333333333333333333333333",
+        "value": "0x1",
+        "gasPrice": 0,
+        "chainId": 61127,
+        "gas": "0x5208",
+    }
     wait_for_transaction_receipt.assert_called_once_with(TX_ID)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -434,7 +434,7 @@ wheels = [
 
 [[package]]
 name = "genlayer-py"
-version = "0.19.0"
+version = "0.19.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "web3" },


### PR DESCRIPTION
## Summary
- set the published Python `localnet` preset to Studio’s canonical local chain ID `61127`
- retain hosted Studio IDs `61997`/`61999` and classify all three presets as Studio chains
- make every Studio preset ID distinct
- keep `uv.lock` synchronized by the release command and reject stale lock metadata in native CI

## Root cause and impact
Python retained its initial `localnet=61999` constant after Studio and genlayer-js moved local Studio to `61127`. Contract deploy/write/appeal/top-up/finalize operations sign with the preset ID, so a normal Python client could submit a raw transaction Studio rejects as `InvalidChainId`.

The cross-repository E2E did not catch this because its harness sets a runtime chain ID and mutates both SDK presets to match it. These new unit tests exercise the shipped preset and the exact transaction passed to the signer instead.

## Validation
- `uv lock --check`
- focused chain + signer suite: 65 passed
- full Python 3.12 unit suite: 224 passed, 17 deselected
- `git diff --check`

## Release
RC1 is immutable; after this lands the v0.19 development branch should cut `0.19.0-rc.2`. The testing-suite RC and Boilerplate release must require rc2, not rc1.

Paired follow-up: update Studio’s stale `.env.example` local ID and add a bootstrap-consistency regression.